### PR TITLE
Highlight the key in keyword lists as an atom

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -258,9 +258,7 @@
    '("\\<\\(true\\|false\\|nil\\)\\>" . font-lock-reference-face)
 
    ;; atoms, generic
-   '("[@:]\\w*" . font-lock-reference-face)
-   '("\\w*:\s" . font-lock-reference-face)
-   '(":\\w*" . font-lock-reference-face))
+   '("[@:]\\w*\\|\\w*:\\s-" . font-lock-reference-face))
   "Highlighting for Elixir mode.")
 
 (defun elixir-mode-cygwin-path (expanded-file-name)


### PR DESCRIPTION
The keys are also atoms, so highlight them as such. Remove a redundant
rule while we're at it.

---

The rule might look a bit strange, but I've found that I need to put it as one regex or the second one won't match. It's bound to be greedy matching or some such, but I haven't been able to figure out why.
