### PR TITLE
Make sure tabs are replace with spaces regardless of the global

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -336,6 +336,7 @@
   (setq mode-name "Elixir")
   (set (make-local-variable 'comment-start) "# ")
   (set (make-local-variable 'comment-end) "")
+  (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-variable-buffer-local 'tab-width) elixir-basic-offset)
   (set (make-variable-buffer-local 'default-tab-width) elixir-basic-offset)
   (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules ; 'elixir-smie-rules


### PR DESCRIPTION
emacs mode.

All the Elixir code I see uses spaces instead of tabs. Right now, it seems like the Elixir mode depends on the global setting.

I'm not an emacs experts I may have made a mistake, but it seems the Elixir standard is double spaces everywhere instead of tabs.
