### PR TITLE
Properly make variables local

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -547,8 +547,8 @@ Argument END End of the region."
   (set (make-local-variable 'comment-start) "# ")
   (set (make-local-variable 'comment-end) "")
   (set (make-local-variable 'comment-use-syntax) t)
-  (set (make-variable-buffer-local 'tab-width) elixir-basic-offset)
-  (set (make-variable-buffer-local 'default-tab-width) elixir-basic-offset)
+  (set (make-local-variable 'tab-width) elixir-basic-offset)
+  (set (make-local-variable 'default-tab-width) elixir-basic-offset)
   (if (boundp 'syntax-propertize-function)
       (set (make-local-variable 'syntax-propertize-function) 'elixir-syntax-propertize))
   (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules ; 'elixir-smie-rules


### PR DESCRIPTION
The function make-variable-buffer-local is used for declaring (at the
top level) that a certain variable should always be made buffer-local
if it is ever changed in any way. For explicitly making a variable
buffer-local, especially within a (set ...), one should use
make-local-variable, which makes a variable buffer-local for the
current buffer.

Emacs warns about this during byte-compilation.
