### PR TITLE
Remove needless statement

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -558,7 +558,6 @@ Argument END End of the region."
   (set (make-local-variable 'comment-end) "")
   (set (make-local-variable 'comment-use-syntax) t)
   (set (make-local-variable 'tab-width) elixir-basic-offset)
-  (set (make-local-variable 'default-tab-width) elixir-basic-offset)
   (set (make-local-variable 'imenu-generic-expression) elixir-imenu-generic-expression)
   (if (boundp 'syntax-propertize-function)
       (set (make-local-variable 'syntax-propertize-function) 'elixir-syntax-propertize))


### PR DESCRIPTION
Changing 'default-tab-width' makes no sense. Only changing 'tab-width'
is enough to changing tab size of buffer.

And 'default-tab-width' causes a byte-compile warning
because it is obsolete variable.
