### PR TITLE
sigil % to ~

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -336,7 +336,7 @@
   "Elixir mode operators.")
 
 (defvar elixir-mode-sigils '("B" "C" "R" "b" "c" "r")
-  "%-prefixed sigils that are understood by `elixir-mode'.")
+  "~-prefixed sigils that are understood by `elixir-mode'.")
 
 (defvar elixir-basic-offset 2)
 (defvar elixir-key-label-offset 0)
@@ -362,8 +362,8 @@
    ;; keywords:
    `(,(concat "\\<" (regexp-opt elixir-mode-keyword-names t) "\\>") . font-lock-keyword-face)
 
-   ;; % Sigils
-   `(,(concat "\\<%" (regexp-opt elixir-mode-sigils t) "\\>") . font-lock-builtin-face)
+   ;; ~ Sigils
+   `(,(concat "\\<~" (regexp-opt elixir-mode-sigils t) "\\>") . font-lock-builtin-face)
 
    ;; builtins:
    `(,(concat "\\<" (regexp-opt elixir-mode-builtin-names t) "\\>") . font-lock-builtin-face)

--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -17,6 +17,7 @@
     ;; work:
     (modify-syntax-entry ?_ "w" elixir-mode-syntax-table)
     (modify-syntax-entry ?? "w" elixir-mode-syntax-table)
+    (modify-syntax-entry ?~ "w" elixir-mode-syntax-table)
 
     (modify-syntax-entry ?' "\"" elixir-mode-syntax-table)
     (modify-syntax-entry ?# "<" elixir-mode-syntax-table)


### PR DESCRIPTION
change sigil character '%' to '~' for v0.12.5
