### PR TITLE
Remove grammar clause for "fn" terminal. Fixes #7

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -240,7 +240,6 @@ Return non-nil if any line breaks were skipped."
            ("try" "do" statements "catch" match-statements "end")
            ("try" "do" statements "end")
            ("case" non-block-expr "do" match-statements "end")
-           ("fn" match-statement "end")
            ("function" "do" match-statements "end")
            (non-block-expr "do" statements "end")
            (expr)

--- a/test/elixir-mode-indentation-tests.el
+++ b/test/elixir-mode-indentation-tests.el
@@ -248,8 +248,7 @@ function do
 end
 ")
 
-(elixir-def-indentation-test indents-fn-in-assignment
-    (:expected-result :failed)
+(elixir-def-indentation-test indents-fn-in-assignment ()
   "
 f = fn x, y ->
 x + y
@@ -259,11 +258,10 @@ f = fn x, y ->
   x + y
 end")
 
-(elixir-def-indentation-test indents-fn-as-arguments
-    (:expected-result :failed)
+(elixir-def-indentation-test indents-fn-as-arguments ()
   "
 Enum.map 1..10, fn x ->
-x+1
+x + 1
 end"
   "
 Enum.map 1..10, fn x ->


### PR DESCRIPTION
After stepping through SMIE functions with EDebug, I realized the only
actual problem in indenting blocks like these is that for the sake of
the grammar, `fn` is considered an opener (I think). I tried many ways to get this
particular issue sorted out, but the simplest was just to remove that
clause from the grammar.
