### PR TITLE
Remove "=" & left-assoc opers from "OP" regex. Fixes #18.

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -84,7 +84,6 @@
                                  "===" "!=="                                                      ; comp3
                                  "==" "!=" "<=" ">="                                              ; comp2
                                  "<" ">"                                                          ; comp1
-                                 "+" "-" "*" "/" "=" "|" "!" "^" "@"                              ; op1
                                  "&&" "||" "<>" "++" "--" "**" "//" "::" "<-"  ".." "/>" "=~"     ; op2 (minus ->)
                                  "xor" "|>"                                                       ; http://elixir-lang.org/docs/stable/Kernel.html
                                  )
@@ -320,7 +319,7 @@ Return non-nil if any line breaks were skipped."
     (`(:after . "end") 0)
     (`(:after . ,(or `"do"))
      elixir-smie-indent-basic)
-    (`(:list-intro . ,(or `"do")) t)))
+    (`(:list-intro . ,(or `"do" `";")) t)))
 
 (define-minor-mode elixir-smie-mode
   "SMIE-based indentation and syntax for Elixir"

--- a/test/elixir-mode-indentation-tests.el
+++ b/test/elixir-mode-indentation-tests.el
@@ -126,20 +126,23 @@ defmodule FooBar do
 end")
 
 (elixir-def-indentation-test indents-after-empty-line
-    (:expected-result :failed) ; #18
+    ()
   "
-a = 2
-
-  b = a + 3
-
-    c = a + b"
-  "
+def foo do
 a = 2
 
 b = a + 3
 
-c = a + b")
+c = a * b
+end"
+  "
+def foo do
+  a = 2
 
+  b = a + 3
+
+  c = a * b
+end")
 
 (elixir-def-indentation-test indents-function-calls-without-parens ()
   "


### PR DESCRIPTION
Munging the right-associative "=" and "+", "-", etc., in with the "OP"
regex was creating issues where they were being treated as "list-intros"
by SMIE.

I have not quite figured out yet how SMIE determines whether something
is a "list-intro" token but this definitely fixes this issue.
