### PR TITLE
Remove grammar entry causing erroneous alignment to ".". Fixes #49

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -264,7 +264,6 @@ Return non-nil if any line breaks were skipped."
            )
           (non-block-expr
            (non-block-expr "OP" non-block-expr)
-           (non-block-expr "DOT" non-block-expr)
            (non-block-expr "COMMA" non-block-expr)
            ("(" statements ")")
            ("{" statements "}")
@@ -275,8 +274,7 @@ Return non-nil if any line breaks were skipped."
            (match-statement))
           (match-statement
            (non-block-expr "->" statements)))
-        '((assoc "DOT")
-          (assoc "if")
+        '((assoc "if")
           (assoc "do:")
           (assoc "else:")
           (assoc "COMMA")

--- a/test/elixir-mode-indentation-tests.el
+++ b/test/elixir-mode-indentation-tests.el
@@ -376,7 +376,7 @@ end"
 end")
 
 (elixir-def-indentation-test indents-list-of-floats-aligns
-    (:expected-result :failed) ; #49
+    ()
   "
 [1.2,
 3.4]"


### PR DESCRIPTION
Thanks to @wolfgang-sosp for pointing out the fix.
