### PR TITLE
Correct auto-mode-alist regexps

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -577,9 +577,9 @@ Argument END End of the region."
 
 ;;;###autoload
 (progn
-  (add-to-list 'auto-mode-alist '("\\.elixir$" . elixir-mode))
-  (add-to-list 'auto-mode-alist '("\\.ex$" . elixir-mode))
-  (add-to-list 'auto-mode-alist '("\\.exs$" . elixir-mode)))
+  (add-to-list 'auto-mode-alist '("\\.elixir\'" . elixir-mode))
+  (add-to-list 'auto-mode-alist '("\\.ex\'" . elixir-mode))
+  (add-to-list 'auto-mode-alist '("\\.exs\'" . elixir-mode)))
 
 (provide 'elixir-mode)
 ;;; elixir-mode.el ends here


### PR DESCRIPTION
`$` matches end of line, `\'` matches end of string. Usually this is not a problem, but the latter is the one we should be using.
