### PR TITLE
Remove unused variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,11 +140,6 @@ Custom variables for elixir-mode.
         <td>Command to start an interactive REPL in <code>IEX</code>.</td>
     </tr>
     <tr>
-        <td><code>elixir-mode-highlight-operators (boolean)</code></td>
-        <td><code>t</code></td>
-        <td>Should operators be colored? (Currently not working properly.)</td>
-    </tr>
-    <tr>
         <td><code>elixir-mode-cygwin-paths (boolean)</code></td>
         <td><code>t</code></td>
         <td>Should Cygwin paths be used on Windows?</td>

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -47,10 +47,6 @@
 ;;
 ;;          Path to the executable <iex> command
 ;;
-;;      `elixir-mode-highlight-operators`
-;;
-;;          Option for whether or not to highlight operators.
-;;
 ;;      `elixir-mode-cygwin-paths`
 ;;
 ;;          Use Cygwin style paths on Windows operating systems.
@@ -189,11 +185,6 @@
 (defcustom elixir-iex-command "iex"
   "Elixir mode command for interactive REPL.  Must be in your path."
   :type 'string
-  :group 'elixir)
-
-(defcustom elixir-mode-highlight-operators t
-  "Elixir mode option for whether or not to highlight operators."
-  :type 'boolean
   :group 'elixir)
 
 (defcustom elixir-mode-cygwin-paths t


### PR DESCRIPTION
Altering font-locking should be done by customizing faces (there can be an operator face that one can simply set to `default`) instead via variables.
