### PR TITLE
Need two backslashes in regex string.

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -562,9 +562,9 @@ Argument END End of the region."
 
 ;;;###autoload
 (progn
-  (add-to-list 'auto-mode-alist '("\\.elixir\'" . elixir-mode))
-  (add-to-list 'auto-mode-alist '("\\.ex\'" . elixir-mode))
-  (add-to-list 'auto-mode-alist '("\\.exs\'" . elixir-mode)))
+  (add-to-list 'auto-mode-alist '("\\.elixir\\'" . elixir-mode))
+  (add-to-list 'auto-mode-alist '("\\.ex\\'" . elixir-mode))
+  (add-to-list 'auto-mode-alist '("\\.exs\\'" . elixir-mode)))
 
 (provide 'elixir-mode)
 ;;; elixir-mode.el ends here


### PR DESCRIPTION
The `auto-mode-alist` regexes in emacs-mode.el all end with "\'" (one backslash + single quote) but they need to end with "\\'" (two backslashes + single quote).

The regexes are trying to match the empty string at the end of a regex (i.e., make sure that the file extension is at the end of the file name). Such a match is represented by either "$" or "\'". However, inside an elisp string the backslash has to be escaped/doubled.
