### PR TITLE
Remove broken SMIE rule.

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -136,7 +136,6 @@
       ((smie-rule-sibling-p) nil)
       ((smie-rule-hanging-p) (smie-rule-parent elixir-smie-indent-basic))
       (t elixir-smie-indent-basic)))
-    (`(:before . "def") elixir-smie-indent-basic)
     ;; If the parent token of `->' is `fn', then we want to align to the
     ;; parent, and offset by `elixir-smie-indent-basic'. Otherwise, indent
     ;; normally. This helps us work with/indent anonymous function blocks

--- a/test/elixir-mode-indentation-tests.el
+++ b/test/elixir-mode-indentation-tests.el
@@ -236,7 +236,7 @@ has_something(x) &&
 (elixir-def-indentation-test indents-last-commented-line
     ()
   "
-defmodule Foo
+defmodule Foo do
 def bar do
 2
 end
@@ -245,7 +245,7 @@ end
 end
 "
   "
-defmodule Foo
+defmodule Foo do
   def bar do
     2
   end


### PR DESCRIPTION
In `elixir-smie-rules` there was a `(:before . "def")` rule that was propping up an incorrectly written test. This rule was breaking indentation for nested modules.
