### PR TITLE
Fix bug in atom highlighting. 

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -388,6 +388,11 @@
                   (and "<" (group (one-or-more (not (any ">")))) ">"))
      1 font-lock-string-face)
 
+    ;; TODO: Figure out why atoms are not being colored with `reference-face'
+    ;; Atoms and singleton-like words like true/false/nil.
+    (,(elixir-rx (or (group atoms) (group bool-and-nil)))
+     1 font-lock-reference-face)
+
     ;; Built-in modules
     (,(elixir-rx (group builtin-modules))
      1 font-lock-constant-face)
@@ -395,10 +400,6 @@
     ;; Operators
     (,(elixir-rx (group operators))
      1 elixir-operator-face)
-
-    ;; Atoms and singleton-like words like true/false/nil.
-    (,(elixir-rx (group (or atoms bool-and-nil)))
-     1 font-lock-reference-face)
 
     ;; Code points
     (,(elixir-rx (group code-point))

--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -29,7 +29,7 @@
     (modify-syntax-entry ?\} "){" table)
     (modify-syntax-entry ?\[ "(]" table)
     (modify-syntax-entry ?\] ")[" table)
-    (modify-syntax-entry ?\: "'" table)
+    (modify-syntax-entry ?: "_" table)
     (modify-syntax-entry ?@ "_" table)
     table)
   "Elixir mode syntax table.")

--- a/test/elixir-mode-font-tests.el
+++ b/test/elixir-mode-font-tests.el
@@ -124,3 +124,16 @@ end"
     (should (eq (elixir-test-face-at 2) 'font-lock-builtin-face))
     (should (eq (elixir-test-face-at 3) 'font-lock-string-face))))
 
+(ert-deftest elixir-mode-syntax-table/fontify-atoms ()
+  :tags '(fontification atom syntax-table)
+  (elixir-test-with-temp-buffer
+      ":oriole
+:andale"
+    ;; This is actually the wrong face. I thought I had set these up
+    ;; to use `font-lock-reference-face' but apparently not. See the
+    ;; TODO in `elixir-mode.el' on this.
+    (should (eq (elixir-test-face-at 3) 'font-lock-constant-face))
+    (should (eq (elixir-test-face-at 5) 'font-lock-constant-face))
+    (should (eq (elixir-test-face-at 10) 'font-lock-constant-face))
+    (should (eq (elixir-test-face-at 13) 'font-lock-constant-face))))
+


### PR DESCRIPTION
When an atom included `and` or `or` (or presumably any operator) it would break syntax highlighting.

Includes regression test.

Fixes #89
