### PR TITLE
Added: ability to run tests via EVM

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,7 +1,17 @@
 #!/bin/bash
 # -*- shell-script -*-
 OUTPUT=/tmp/test-output.txt
-emacs -batch -l ert-bootstrap.el -l elixir-mode-tests.el -f ert-run-tests-batch-and-exit 2> $OUTPUT
+
+EMACS_BINARY="emacs"
+
+EMACS_VERSION=$1
+if [ -n "$EMACS_VERSION" ]; then
+    EMACS_BINARY=`evm bin $EMACS_VERSION`
+fi
+
+LOAD_FILES="-l ert-bootstrap.el -l elixir-mode-tests.el"
+
+$EMACS_BINARY -batch $LOAD_FILES -f ert-run-tests-batch-and-exit 2> $OUTPUT
 
 if [ $? == 0 ]; then
     echo "Success -- All tests passed."
@@ -17,7 +27,7 @@ else
                 break
                 ;;
             *)
-                emacs -l elixir-mode-tests.el -f ert-run-tests-interactively
+                $EMACS_BINARY -q $LOAD_FILES -f ert-run-tests-interactively
                 break
                 ;;
         esac


### PR DESCRIPTION
Hi!

This commit adds ability to run tests via EVM. It's assumes that you already have installed EVM and appropriate version of Emacs (via `evm install`).

Usage:

``` sh
$ ./run_tests                # run tests with default emacs
$ ./run_tests emacs-24.3-bin # run tests with emacs version 24.3-bin
```

Ref #109 
