### PR TITLE
TravisCI: add-apt-repository and apt-get install fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_install:
   - sudo add-apt-repository -y ppa:$EMACS_REPO
   - sudo apt-get update
-  - sudo apt-get install $EMACS
+  - sudo apt-get -y install $EMACS
   - cd /tmp
   - wget https://github.com/elixir-lang/elixir/releases/download/v1.0.0/Precompiled.zip
   - unzip Precompiled.zip


### PR DESCRIPTION
For some reasons it wasn't required earlier.
