### PR TITLE
Added: test coverage with undercover.el

### DIFF
--- a/Cask
+++ b/Cask
@@ -6,4 +6,5 @@
 (files "*.el")
 
 (development
+ (depends-on "undercover")
  (depends-on "ert-runner"))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Elixir Mode [![Build Status](https://travis-ci.org/elixir-lang/emacs-elixir.svg?branch=master)](https://travis-ci.org/elixir-lang/emacs-elixir)
+# Elixir Mode [![Build Status](https://travis-ci.org/elixir-lang/emacs-elixir.svg?branch=master)](https://travis-ci.org/elixir-lang/emacs-elixir) [![Coverage Status](https://img.shields.io/coveralls/elixir-lang/emacs-elixir.svg)](https://coveralls.io/r/elixir-lang/emacs-elixir)
 
 Provides font-locking, indentation and navigation support for the
 [Elixir programming language.](http://elixir-lang.org/)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,5 +1,6 @@
 
 (require 'ert-x)
+(require 'undercover)
 
 (message "Running tests on Emacs %s" emacs-version)
 
@@ -9,6 +10,7 @@
               indent-tabs-mode nil)
 
 ;; Load the elixir-mode under test
+(undercover "*.el")
 (require 'elixir-mode)
 
 ;; Helpers


### PR DESCRIPTION
Hi!

I have released a new Emacs library [undercover.el](https://github.com/sviridov/undercover.el) that provides a test coverage check for Emacs packages.

This commit adds [undercover.el](https://github.com/sviridov/undercover.el) to emacs-elixir. [Check](https://coveralls.io/r/sviridov/emacs-elixir) my fork coverage results.

Somebody should enable elixir-lang/emacs-elixir for [Coveralls](https://coveralls.io/).

Screenshots:

![1](https://cloud.githubusercontent.com/assets/1789390/4490597/14a2dc0e-4a2e-11e4-9816-5ca256dac7a4.png)
![2](https://cloud.githubusercontent.com/assets/1789390/4490598/14a34176-4a2e-11e4-97c4-e030db708c98.png)
