### PR TITLE
Expand def of block operator regex to include non-newlines.

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -120,7 +120,7 @@
           ">=" "<" ">" "&&" "||" "<>" "++" "--" "//" "/>" "=~" "|>")))
 
 (defvar elixir-smie--block-operator-regexp
-  (rx "->"))
+  (rx "->" (0+ nonl)))
 
 (defvar elixir-smie--spaces-til-eol-regexp
   (rx (and (1+ space) eol))

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -497,8 +497,7 @@ end"
   end
 end")
 
-(elixir-def-indentation-test cond-comment
-    (:expected-result :failed)
+(elixir-def-indentation-test cond-comment ()
   "
 def foo() do
 cond do
@@ -599,8 +598,7 @@ def foo do #comment
 end")
 
 (elixir-def-indentation-test indent-single-line-match
-  (:expected-result :failed
-   :tags '(indentation))
+  (:tags '(indentation))
    "
 case x do
 a -> b


### PR DESCRIPTION
This moved a couple tests to the "passing" column.
