### PR TITLE
rework MELPA install section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,32 @@ Provides font-locking, indentation and navigation support for the
 
 ## Installation
 
-### ELPA
+### (M)ELPA
 
-elixir-mode is available on the community maintained repository -
-[MELPA](http://stable.melpa.org/). Just run `M-x package-install
-[RET] elixir-mode [RET]` inside your emacs and you're ready to go.
+If you're not already using ELPA, check the
+[emacswiki](http://www.emacswiki.org/emacs/ELPA) page to get familiar with it.
+elixir-mode is available on the community maintained repository:
+[MELPA](http://stable.melpa.org/)
 
-**Please take note of the MELPA URL.** We strive for the most responsible
-release management possible (to the best of our knowledge & abilities). To that
-end, please ensure you are *only* using [MELPA Stable](http://stable.melpa.org)
-to retrieve this package. If you use [regular MELPA](http://melpa.org), you will
-be installing the latest changes to master, not the latest release.
+1. Add the (stable) package source: `http://stable.melpa.org/packages/`
+2. Install elixir-mode package
 
-If you're not already using ELPA, check the [emacswiki](http://www.emacswiki.org/emacs/ELPA) page to get
-familiar with it.
+
+[In your (e.g.) .emacs](http://stable.melpa.org/#/getting-started)
+
+    (add-to-list 'package-archives
+                 '("melpa-stable" . "http://stable.melpa.org/packages/") t)
+
+In your emacs
+
+    M-x package-install
+    elixir-mode
+
+**Please take note of the [packages URL](http://stable.melpa.org/packages/)!**
+We strive for the most responsible release management possible (to the best
+of our knowledge & abilities). To that end, please ensure you are *only* using
+[MELPA Stable](http://stable.melpa.org). If you use [regular MELPA](http://melpa.org), you will be installing the *latest changes to master*, not the latest
+release.
 
 ### Download latest release
 


### PR DESCRIPTION
I had trouble with the instructions the first time through.  It wasn't clear that I had to add the MELPA package source, and once I figured that out, the URL source wasn't clear.  I reworked the section to make these clear, maintaining the existing verbiage wherever possible.  I also added some line breaks for the sake of 80ch line lengths.
