### PR TITLE
run emacs-snapshot in --no-win mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: erlang
 otp_release:
    - 17.1
 env:
-  - EMACS=emacs24 EMACS_REPO=cassou/emacs
-  - EMACS=emacs-snapshot EMACS_REPO=ubuntu-elisp/ppa
+  - EMACS=emacs24 EMACS_REPO=cassou/emacs TEST_RUN="rake test"
+  - EMACS=emacs-snapshot EMACS_REPO=ubuntu-elisp/ppa TEST_RUN="rake test-no-gui"
 before_install:
   - sudo add-apt-repository -y ppa:$EMACS_REPO
   - sudo apt-get update
@@ -16,4 +16,4 @@ before_install:
   - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
   - export PATH="/home/travis/.cask/bin:$PATH"
 script:
-  - rake test
+  - $TEST_RUN

--- a/Rakefile
+++ b/Rakefile
@@ -45,6 +45,22 @@ task "test" do
   exit_when_failed!("Test suite failed!\n")
 end
 
+desc "Run test suite with Emacs without GUI window"
+task "test-no-gui" do
+  process_info "Install package dependencies"
+  say ""
+  say "#{indent(3)}Command: ", :yellow, false
+  sh "cask install"
+  say ""
+
+  process_info "Run test suite with --no-win"
+  say ""
+  system "#{CASK} exec ert-runner --no-win"
+
+  print_when_success("Test suite success\n")
+  exit_when_failed!("Test suite failed!\n")
+end
+
 namespace :testing do
   desc "Run indentation test suite"
   task "indentation" do
@@ -92,6 +108,12 @@ def exit_when_failed!(message)
   if $?.exitstatus != 0
     warning(message)
     exit(1)
+  end
+end
+
+def print_when_success(message)
+  if $?.exitstatus == 0
+    info(message)
   end
 end
 


### PR DESCRIPTION
In the current emacs-snapshot the the suite for indentation fail in batch mode. The indentation inside an running emacs session though, is working without any problems.

To get around this issue we run the indentation test suite now with `ert-runner --no-win` to test the indentation inside emacs-snapshot properly. 
