### PR TITLE
Removed unused lexical variable

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -469,8 +469,7 @@ just return nil."
 
 (defun elixir-beginning-of-defun (&optional arg)
   (interactive "p")
-  (let ((command last-command)
-        (regexp (concat "^\\s-*" (elixir-rx builtin-declaration)))
+  (let ((regexp (concat "^\\s-*" (elixir-rx builtin-declaration)))
         case-fold-search)
     (while (and (re-search-backward regexp nil t (or arg 1))
                 (elixir-syntax-in-string-or-comment-p)))


### PR DESCRIPTION
Removed unused lexical variable `command` from `elixir-beginning-of-defun`