### PR TITLE
Fix `elixir-format-hook` quoting in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ To use a `.formatter.exs` you can either set `elixir-format-arguments` globally 
 or you set `elixir-format-arguments` in a hook like this:
 
 ``` elisp
-(add-hook elixir-format-hook '(lambda ()
+(add-hook 'elixir-format-hook (lambda ()
                                  (if (projectile-project-p)
                                      (setq elixir-format-arguments (list "--dot-formatter" (concat (projectile-project-root) "/.formatter.exs")))
                                    (setq elixir-format-arguments nil))))


### PR DESCRIPTION
The quote was on the `lambda`, instead of the name, causing an error at startup:
`Symbol’s value as variable is void: elixir-format-hook`