### PR TITLE
Locate closest .formatter.exs from the file formatted on save

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ or you set `elixir-format-arguments` in a hook like this:
 ``` elisp
 (add-hook 'elixir-format-hook (lambda ()
                                  (if (projectile-project-p)
-                                     (setq elixir-format-arguments (list "--dot-formatter" (concat (projectile-project-root) "/.formatter.exs")))
+                                      (setq elixir-format-arguments
+                                            (list "--dot-formatter"
+                                                  (concat (locate-dominating-file buffer-file-name ".formatter.exs") ".formatter.exs")))
                                    (setq elixir-format-arguments nil))))
 ```
 


### PR DESCRIPTION
An umbrella app can have the following file tree:
```
${PROJECT_ROOT}/.formatter.exs
${PROJECT_ROOT}/apps/app1/.formatter.exs
```
In the case we run the `elixir-format` command in an elixir file located under the `app1` application, the formatter used should be the one from `app1`, and not the one from the root.

The PR intends to give as default an example with the closest `.formatter.exs` instead of the project one, thanks to the emacs function `locate-dominating-file`.