### PR TITLE
fix: fontify defguard and defguardp

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -124,7 +124,8 @@
                                   (or "def" "defp" "defmodule" "defprotocol"
                                       "defmacro" "defmacrop" "defdelegate"
                                       "defexception" "defstruct" "defimpl"
-                                      "defcallback" "defoverridable")
+                                      "defguard" "defguardp" "defcallback"
+                                      "defoverridable")
                                   symbol-end))
       (builtin-namespace . ,(rx symbol-start
                                 (or "import" "require" "use" "alias")

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -110,6 +110,22 @@ x = 15"
 x = 15"
     (should (eq (elixir-test-face-at 15) 'font-lock-variable-name-face))))
 
+(ert-deftest elixir-mode-syntax-table/fontify-defguard ()
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+      "defmodule Foo do
+defguard is_foo(arg) when arg == true
+end"
+    (should (eq (elixir-test-face-at 18) 'font-lock-keyword-face))))
+
+(ert-deftest elixir-mode-syntax-table/fontify-defguardp ()
+  :tags '(fontification syntax-table)
+  (elixir-test-with-temp-buffer
+      "defmodule Foo do
+defguardp is_foo(arg) when arg == true
+end"
+    (should (eq (elixir-test-face-at 18) 'font-lock-keyword-face))))
+
 (ert-deftest elixir-mode-syntax-table/fontify-function-name/1 ()
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
@@ -586,8 +602,6 @@ Everything in here should be gray, including the @doc and triple-quotes
     (should (eq 'font-lock-doc-face (get-char-property (point) 'face)))
     (search-forward "Everything")
     (should (eq 'font-lock-doc-face (get-char-property (point) 'face)))))
-
-
 
 (provide 'elixir-mode-font-test)
 


### PR DESCRIPTION
`defguard` and `defguardp` were not being properly fontified. They were included in Elixir 1.7.

My setup:

- `elixir-mode-version`: 2.3.1
- Emacs version: 26.1
- Fedora 28 amd64:
```
-> uname -a
Linux 4.17.19-200.fc28.x86_64 #1 SMP Fri Aug 24 15:47:41 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```