### PR TITLE
Special case for indentation of fat arrows in map literals.

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -415,6 +415,8 @@
        (smie-rule-parent))
       ((smie-rule-parent-p ";")
        (smie-rule-parent))
+      ((smie-rule-parent-p "{")
+       (smie-rule-parent elixir-smie-indent-basic))
       (t (smie-rule-parent (- elixir-smie-indent-basic)))))
     (`(:before . "MATCH-STATEMENT-DELIMITER")
      (cond

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1526,6 +1526,23 @@ end")
   }
 }")
 
+(elixir-def-indentation-test indent-maps-with-multiple-string-keys
+                             (:expected-result :failed :tags '(indentation))
+"Enum.map [], fn x ->
+%{
+\"a\" => 5555,
+\"b\" => 5555,
+\"c\" => x,
+}
+end"
+"Enum.map [], fn x ->
+  %{
+    \"a\" => 5555,
+    \"b\" => 5555,
+    \"c\" => x,
+  }
+end")
+
 (elixir-def-indentation-test indent-maps-and-structs-elements
                              (:tags '(indentation))
 "

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -1510,7 +1510,7 @@ defmodule Foo do
 end")
 
 (elixir-def-indentation-test indent-maps-with-stings-as-keys
-                             (:expected-result :failed :tags '(indentation))
+                             (:tags '(indentation))
 "%{
 \"data\" => %{
 \"foo\" => %{


### PR DESCRIPTION
I have no idea why "=>" classifies as "OP", but apparently that makes it want to outdent the next line instead of indenting it in map literals.

I'm pretty sure the grammar is wrong here, but...

Relevant to #359.