### PR TITLE
Add support for `~U` sigil

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -172,7 +172,7 @@
                          (or "_" "__MODULE__" "__DIR__" "__ENV__" "__CALLER__"
                              "__block__" "__aliases__")
                          symbol-end))
-      (sigils . ,(rx "~" (or "B" "C" "D" "N" "R" "S" "T" "b" "c" "r" "s" "w")))))
+      (sigils . ,(rx "~" (or "B" "C" "D" "N" "R" "S" "T" "U" "b" "c" "r" "s" "w")))))
 
   (defmacro elixir-rx (&rest sexps)
     (let ((rx-constituents (append elixir-rx-constituents rx-constituents)))


### PR DESCRIPTION
`~U` has been recently introduced. See https://github.com/elixir-lang/elixir/issues/8821 for context.