### PR TITLE
Fix a bug of font-lock high CPU / freeze

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -399,7 +399,7 @@ is used to limit the scan."
      1 font-lock-variable-name-face)
 
     ;; Map keys
-    (,(elixir-rx (group (and (one-or-more identifiers) ":")) space)
+    (,(elixir-rx (group (and identifiers ":")) space)
      1 elixir-atom-face)
 
     ;; Pseudovariables


### PR DESCRIPTION
According to issue #445, every time a `.ex` file is opened, `font-lock-fontify-keywords-region` will take 100% of CPU usage and completely freeze Emacs. 