### PR TITLE
Make usable again in Emacs 27

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -134,7 +134,7 @@
       ;; The first character of an identifier must be a letter or an underscore.
       ;; After that, they may contain any alphanumeric character + underscore.
       ;; Additionally, the final character may be either `?' or `!'.
-      (identifiers . ,(rx (one-or-more (any "A-Z" "a-z" "_"))
+      (identifiers . ,(rx (any "A-Z" "a-z" "_")
                           (zero-or-more (any "A-Z" "a-z" "0-9" "_"))
                           (optional (or "?" "!"))))
       (keyword . ,(rx symbol-start
@@ -151,11 +151,11 @@
       ;; or `!'.
       (module-names . ,(rx symbol-start
                            (optional (or "%" "&"))
-                           (one-or-more (any "A-Z"))
+                           (any "A-Z")
                            (zero-or-more (any "A-Z" "a-z" "_" "0-9"))
                            (zero-or-more
                             (and "."
-                                 (one-or-more (any "A-Z" "_"))
+                                 (any "A-Z" "_")
                                  (zero-or-more (any "A-Z" "a-z" "_" "0-9"))))
                            (optional (or "!" "?"))
                            symbol-end))

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -304,7 +304,7 @@ is used to limit the scan."
     (elixir-match-interpolation 0 font-lock-variable-name-face t)
 
     ;; Module attributes
-    (,(elixir-rx (and "@" (1+ identifiers)))
+    (,(elixir-rx (and "@" identifiers))
      0 elixir-attribute-face)
 
     ;; Keywords
@@ -399,7 +399,7 @@ is used to limit the scan."
      1 font-lock-variable-name-face)
 
     ;; Map keys
-    (,(elixir-rx (group (and (one-or-more identifiers) ":")) space)
+    (,(elixir-rx (group (and identifiers ":")) space)
      1 elixir-atom-face)
 
     ;; Pseudovariables


### PR DESCRIPTION
As it is now, it freezes on opening any non-trivial file (it's actually just applying font-lock rules very slowly).

It *is* a bug in elixir-mode, not Emacs. See https://debbugs.gnu.org/38104#20 for full explanation.

Fixes #445.