### PR TITLE
Disable smie-blink-matching-inners locally

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -538,7 +538,10 @@ just return nil."
 
   (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules
               :forward-token 'elixir-smie-forward-token
-              :backward-token 'elixir-smie-backward-token))
+              :backward-token 'elixir-smie-backward-token)
+  ;; https://github.com/elixir-editors/emacs-elixir/issues/363
+  ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=35496
+  (set (make-local-variable 'smie-blink-matching-inners) nil))
 
 ;; Invoke elixir-mode when appropriate
 


### PR DESCRIPTION
Re-fixes #363 ("hang after RET") in a better way and fixes #440.

It's a subtle bug in SMIE which is triggered by SMIE's grammar having
both "do" and "do:". No fix in sight, and we have to support older
Emacs anyway.

The previous fix for #363 was to break the grammar, crippling `show-paren-mode` and sexp navigation in elixir-mode buffers.

Please merge this so we can go on ahead with fixing the grammar.