### PR TITLE
chore: update repo url everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,111 +1,111 @@
 ## v2.3.1 - 2016/04/19
-* [#337](https://github.com/elixir-lang/emacs-elixir/pull/337) - Fix indentation issue after COMMA token
-* [#333](https://github.com/elixir-lang/emacs-elixir/pull/333) - Fix indentation of second element inside list of tuples
-* [#332](https://github.com/elixir-lang/emacs-elixir/pull/332) - Correct indent after using 'for' as function name
-* [#329](https://github.com/elixir-lang/emacs-elixir/pull/329) - Indent by one level if current line belongs to function call
+* [#337](https://github.com/elixir-editors/emacs-elixir/pull/337) - Fix indentation issue after COMMA token
+* [#333](https://github.com/elixir-editors/emacs-elixir/pull/333) - Fix indentation of second element inside list of tuples
+* [#332](https://github.com/elixir-editors/emacs-elixir/pull/332) - Correct indent after using 'for' as function name
+* [#329](https://github.com/elixir-editors/emacs-elixir/pull/329) - Indent by one level if current line belongs to function call
 
 ## v2.3.0 - 2016/04/13
-* [#327](https://github.com/elixir-lang/emacs-elixir/pull/327) - Correct indentation of maps inside lists
-* [#326](https://github.com/elixir-lang/emacs-elixir/pull/326) - Correct anonymous fun indent inside block
-* [#325](https://github.com/elixir-lang/emacs-elixir/pull/325) - Fix indentation of statement keywords on dot call
-* [#324](https://github.com/elixir-lang/emacs-elixir/pull/324) - added failing tests for named functions in if and case
-* [#322](https://github.com/elixir-lang/emacs-elixir/pull/322) - added a failing indentation test for cond within with
-* [#321](https://github.com/elixir-lang/emacs-elixir/pull/321) - Fix invalid highlighting '::' in binaries
-* [#318](https://github.com/elixir-lang/emacs-elixir/pull/318) - Fix indent of pipes inside blocks of 'def' for example
+* [#327](https://github.com/elixir-editors/emacs-elixir/pull/327) - Correct indentation of maps inside lists
+* [#326](https://github.com/elixir-editors/emacs-elixir/pull/326) - Correct anonymous fun indent inside block
+* [#325](https://github.com/elixir-editors/emacs-elixir/pull/325) - Fix indentation of statement keywords on dot call
+* [#324](https://github.com/elixir-editors/emacs-elixir/pull/324) - added failing tests for named functions in if and case
+* [#322](https://github.com/elixir-editors/emacs-elixir/pull/322) - added a failing indentation test for cond within with
+* [#321](https://github.com/elixir-editors/emacs-elixir/pull/321) - Fix invalid highlighting '::' in binaries
+* [#318](https://github.com/elixir-editors/emacs-elixir/pull/318) - Fix indent of pipes inside blocks of 'def' for example
 
 ## v2.2.9 - 2016/04/03
-* [#317](https://github.com/elixir-lang/emacs-elixir/pull/317) - Correct pipeline indentation
-* [#316](https://github.com/elixir-lang/emacs-elixir/pull/316) - Fix indentation of if within an else block
-* [#315](https://github.com/elixir-lang/emacs-elixir/pull/315) - Correct indentation with for-comprehensions within blocks
-* [#314](https://github.com/elixir-lang/emacs-elixir/pull/314) - Fix highlighting triple single quote(heredoc)
-* [#313](https://github.com/elixir-lang/emacs-elixir/pull/313) - Correct indentation after a one line 'fn' definition
-* [#305](https://github.com/elixir-lang/emacs-elixir/pull/305) - Added test case for for-comprehensions within case
-* [#303](https://github.com/elixir-lang/emacs-elixir/pull/303) - Fix escaped delimiter in sigil issue
-* [#295](https://github.com/elixir-lang/emacs-elixir/pull/295) - Demonstrate defstruct indention in a test case
-* [#261](https://github.com/elixir-lang/emacs-elixir/pull/261) - Test for multi-line function calls without parenthesis
-* [#299](https://github.com/elixir-lang/emacs-elixir/pull/299) - Added `with/1` to the highlighted keywords
-* [#298](https://github.com/elixir-lang/emacs-elixir/pull/298) - Added a test for alignment of the last key in multiline maps in cases
-* [#296](https://github.com/elixir-lang/emacs-elixir/pull/296) - Gray out ignored variables
-* [#291](https://github.com/elixir-lang/emacs-elixir/pull/291) - Added a test for indenting non-finished one-line if-else
-* [#289](https://github.com/elixir-lang/emacs-elixir/pull/289) - Added a test case for if within an else
-* [#287](https://github.com/elixir-lang/emacs-elixir/pull/287) - Fix sigil triple quotes
-* [#284](https://github.com/elixir-lang/emacs-elixir/pull/284) - Added a test for highlighting end after comment
-* [#285](https://github.com/elixir-lang/emacs-elixir/pull/285) - Don't capture '(or line-start (not (any ".")))'
-* [#282](https://github.com/elixir-lang/emacs-elixir/pull/282) - Indent multiple macro calls with do colon correct
-* [#280](https://github.com/elixir-lang/emacs-elixir/pull/280) - Fix one line definitions with equal char inside guard
-* [#279](https://github.com/elixir-lang/emacs-elixir/pull/279) - Fix indentation of single line fun declarations after single line fun declarations with when clauses
-* [#277](https://github.com/elixir-lang/emacs-elixir/pull/277) - Fix syntax highlighting sigils in string
-* [#273](https://github.com/elixir-lang/emacs-elixir/pull/273) - Removed send_after from highlighted keywords
-* [#272](https://github.com/elixir-lang/emacs-elixir/pull/272) - Added `send` and `send_after` to font lock
-* [#271](https://github.com/elixir-lang/emacs-elixir/pull/271) - Highlight module if preceded by a pipe
+* [#317](https://github.com/elixir-editors/emacs-elixir/pull/317) - Correct pipeline indentation
+* [#316](https://github.com/elixir-editors/emacs-elixir/pull/316) - Fix indentation of if within an else block
+* [#315](https://github.com/elixir-editors/emacs-elixir/pull/315) - Correct indentation with for-comprehensions within blocks
+* [#314](https://github.com/elixir-editors/emacs-elixir/pull/314) - Fix highlighting triple single quote(heredoc)
+* [#313](https://github.com/elixir-editors/emacs-elixir/pull/313) - Correct indentation after a one line 'fn' definition
+* [#305](https://github.com/elixir-editors/emacs-elixir/pull/305) - Added test case for for-comprehensions within case
+* [#303](https://github.com/elixir-editors/emacs-elixir/pull/303) - Fix escaped delimiter in sigil issue
+* [#295](https://github.com/elixir-editors/emacs-elixir/pull/295) - Demonstrate defstruct indention in a test case
+* [#261](https://github.com/elixir-editors/emacs-elixir/pull/261) - Test for multi-line function calls without parenthesis
+* [#299](https://github.com/elixir-editors/emacs-elixir/pull/299) - Added `with/1` to the highlighted keywords
+* [#298](https://github.com/elixir-editors/emacs-elixir/pull/298) - Added a test for alignment of the last key in multiline maps in cases
+* [#296](https://github.com/elixir-editors/emacs-elixir/pull/296) - Gray out ignored variables
+* [#291](https://github.com/elixir-editors/emacs-elixir/pull/291) - Added a test for indenting non-finished one-line if-else
+* [#289](https://github.com/elixir-editors/emacs-elixir/pull/289) - Added a test case for if within an else
+* [#287](https://github.com/elixir-editors/emacs-elixir/pull/287) - Fix sigil triple quotes
+* [#284](https://github.com/elixir-editors/emacs-elixir/pull/284) - Added a test for highlighting end after comment
+* [#285](https://github.com/elixir-editors/emacs-elixir/pull/285) - Don't capture '(or line-start (not (any ".")))'
+* [#282](https://github.com/elixir-editors/emacs-elixir/pull/282) - Indent multiple macro calls with do colon correct
+* [#280](https://github.com/elixir-editors/emacs-elixir/pull/280) - Fix one line definitions with equal char inside guard
+* [#279](https://github.com/elixir-editors/emacs-elixir/pull/279) - Fix indentation of single line fun declarations after single line fun declarations with when clauses
+* [#277](https://github.com/elixir-editors/emacs-elixir/pull/277) - Fix syntax highlighting sigils in string
+* [#273](https://github.com/elixir-editors/emacs-elixir/pull/273) - Removed send_after from highlighted keywords
+* [#272](https://github.com/elixir-editors/emacs-elixir/pull/272) - Added `send` and `send_after` to font lock
+* [#271](https://github.com/elixir-editors/emacs-elixir/pull/271) - Highlight module if preceded by a pipe
 
 ## v2.2.8 - 2015/10/19
-* [#270](https://github.com/elixir-lang/emacs-elixir/pull/270) - Fix highlighting hashmark in sigil
-* [#269](https://github.com/elixir-lang/emacs-elixir/pull/269) - Fix string interpolation
-* [#268](https://github.com/elixir-lang/emacs-elixir/pull/268) - added font-lock to defoverridable
-* [#262](https://github.com/elixir-lang/emacs-elixir/pull/262) - Add indentation tests for comprehensions
-* [#267](https://github.com/elixir-lang/emacs-elixir/pull/267) - ~s is sigil, not attribute
-* [#266](https://github.com/elixir-lang/emacs-elixir/pull/266) - Fix quotes in sigils
-* [#264](https://github.com/elixir-lang/emacs-elixir/pull/264) - Fix string interpolation
+* [#270](https://github.com/elixir-editors/emacs-elixir/pull/270) - Fix highlighting hashmark in sigil
+* [#269](https://github.com/elixir-editors/emacs-elixir/pull/269) - Fix string interpolation
+* [#268](https://github.com/elixir-editors/emacs-elixir/pull/268) - added font-lock to defoverridable
+* [#262](https://github.com/elixir-editors/emacs-elixir/pull/262) - Add indentation tests for comprehensions
+* [#267](https://github.com/elixir-editors/emacs-elixir/pull/267) - ~s is sigil, not attribute
+* [#266](https://github.com/elixir-editors/emacs-elixir/pull/266) - Fix quotes in sigils
+* [#264](https://github.com/elixir-editors/emacs-elixir/pull/264) - Fix string interpolation
 
 ## v2.2.7 - 2015/09/17
-* [#260](https://github.com/elixir-lang/emacs-elixir/pull/260) - Correct indentation after "for" comprehension
-* [#259](https://github.com/elixir-lang/emacs-elixir/pull/259) - Indent receive/after matches correct
-* [#258](https://github.com/elixir-lang/emacs-elixir/pull/258) - Emacs hangs if `elixir-smie-forward-token` returns an empty string
-* [#253](https://github.com/elixir-lang/emacs-elixir/pull/253) - Fix Highlight atom issue(atom contains '!', '?', '@')
-* [#252](https://github.com/elixir-lang/emacs-elixir/pull/252) - Fix after dot highlighting
-* [#249](https://github.com/elixir-lang/emacs-elixir/pull/249) - Add correct indent for "if" inside a "->" block
-* [#246](https://github.com/elixir-lang/emacs-elixir/pull/246) - Fix highlighting true, false, nil
-* [#244](https://github.com/elixir-lang/emacs-elixir/pull/244) - True,false, nil are highlighted as atoms
-* [#241](https://github.com/elixir-lang/emacs-elixir/pull/241) - correct indent for oneline `do:` when moved to next line
-* [#240](https://github.com/elixir-lang/emacs-elixir/pull/240) - Correct indent in case expression when returning a tuple
-* [#236](https://github.com/elixir-lang/emacs-elixir/pull/236) - fontify special macros with prefix like '%' and '&'
-* [#235](https://github.com/elixir-lang/emacs-elixir/pull/235) - correct indentation for identifiers which contains built in words after a dot
+* [#260](https://github.com/elixir-editors/emacs-elixir/pull/260) - Correct indentation after "for" comprehension
+* [#259](https://github.com/elixir-editors/emacs-elixir/pull/259) - Indent receive/after matches correct
+* [#258](https://github.com/elixir-editors/emacs-elixir/pull/258) - Emacs hangs if `elixir-smie-forward-token` returns an empty string
+* [#253](https://github.com/elixir-editors/emacs-elixir/pull/253) - Fix Highlight atom issue(atom contains '!', '?', '@')
+* [#252](https://github.com/elixir-editors/emacs-elixir/pull/252) - Fix after dot highlighting
+* [#249](https://github.com/elixir-editors/emacs-elixir/pull/249) - Add correct indent for "if" inside a "->" block
+* [#246](https://github.com/elixir-editors/emacs-elixir/pull/246) - Fix highlighting true, false, nil
+* [#244](https://github.com/elixir-editors/emacs-elixir/pull/244) - True,false, nil are highlighted as atoms
+* [#241](https://github.com/elixir-editors/emacs-elixir/pull/241) - correct indent for oneline `do:` when moved to next line
+* [#240](https://github.com/elixir-editors/emacs-elixir/pull/240) - Correct indent in case expression when returning a tuple
+* [#236](https://github.com/elixir-editors/emacs-elixir/pull/236) - fontify special macros with prefix like '%' and '&'
+* [#235](https://github.com/elixir-editors/emacs-elixir/pull/235) - correct indentation for identifiers which contains built in words after a dot
 
 ## v2.2.6 - 2015/08/05
-* [#234](https://github.com/elixir-lang/emacs-elixir/pull/234) - don't highlights LHS as a variable in `==` case fixes #225
-* [#233](https://github.com/elixir-lang/emacs-elixir/pull/233) - module syntax highlighting also works correctly with &
-* [#232](https://github.com/elixir-lang/emacs-elixir/pull/232) - correct indentation for closing Map curly bracket fixes #223
-* [#231](https://github.com/elixir-lang/emacs-elixir/pull/231) - correct indentation for block with multiple matches
-* [#230](https://github.com/elixir-lang/emacs-elixir/pull/230) - update travis setup
-* [#228](https://github.com/elixir-lang/emacs-elixir/pull/228) - clear elixir-mode from deprecated functions
+* [#234](https://github.com/elixir-editors/emacs-elixir/pull/234) - don't highlights LHS as a variable in `==` case fixes #225
+* [#233](https://github.com/elixir-editors/emacs-elixir/pull/233) - module syntax highlighting also works correctly with &
+* [#232](https://github.com/elixir-editors/emacs-elixir/pull/232) - correct indentation for closing Map curly bracket fixes #223
+* [#231](https://github.com/elixir-editors/emacs-elixir/pull/231) - correct indentation for block with multiple matches
+* [#230](https://github.com/elixir-editors/emacs-elixir/pull/230) - update travis setup
+* [#228](https://github.com/elixir-editors/emacs-elixir/pull/228) - clear elixir-mode from deprecated functions
 
 ## v2.2.5 - 2015/06/18
-* [#222](https://github.com/elixir-lang/emacs-elixir/pull/222) - correct indentation inside heredoc strings
-* [#221](https://github.com/elixir-lang/emacs-elixir/pull/221) - highlight atoms correctly in a pattern match
-* [#220](https://github.com/elixir-lang/emacs-elixir/pull/220) - Correct indentation of parenthesized expression inside blocks
-* [#214](https://github.com/elixir-lang/emacs-elixir/pull/214) - correct indentation after one line definition with if keyword
-* [#213](https://github.com/elixir-lang/emacs-elixir/pull/213) - remove do keyword to handle also oneline definitions
+* [#222](https://github.com/elixir-editors/emacs-elixir/pull/222) - correct indentation inside heredoc strings
+* [#221](https://github.com/elixir-editors/emacs-elixir/pull/221) - highlight atoms correctly in a pattern match
+* [#220](https://github.com/elixir-editors/emacs-elixir/pull/220) - Correct indentation of parenthesized expression inside blocks
+* [#214](https://github.com/elixir-editors/emacs-elixir/pull/214) - correct indentation after one line definition with if keyword
+* [#213](https://github.com/elixir-editors/emacs-elixir/pull/213) - remove do keyword to handle also oneline definitions
 
 ## v2.2.4 - 2015/05/26
-* [#203](https://github.com/elixir-lang/emacs-elixir/pull/203) - Implement triple-quoted strings.
+* [#203](https://github.com/elixir-editors/emacs-elixir/pull/203) - Implement triple-quoted strings.
 
 ## v2.2.3 - 2015/05/26
-* [#202](https://github.com/elixir-lang/emacs-elixir/pull/202) - correct indentation after oneline def/if definition
-* [#200](https://github.com/elixir-lang/emacs-elixir/pull/200) - correct elements indentation for structs, maps and tuples
-* [#198](https://github.com/elixir-lang/emacs-elixir/pull/198) - indenting elements of a list correctly
-* [#196](https://github.com/elixir-lang/emacs-elixir/pull/196) - correct indentation outside of blocks
+* [#202](https://github.com/elixir-editors/emacs-elixir/pull/202) - correct indentation after oneline def/if definition
+* [#200](https://github.com/elixir-editors/emacs-elixir/pull/200) - correct elements indentation for structs, maps and tuples
+* [#198](https://github.com/elixir-editors/emacs-elixir/pull/198) - indenting elements of a list correctly
+* [#196](https://github.com/elixir-editors/emacs-elixir/pull/196) - correct indentation outside of blocks
 
 ## v2.2.2 - 2015/05/22
-* [#193](https://github.com/elixir-lang/emacs-elixir/pull/193) - fix wrong indentation on empty line between existing code
-* [#195](https://github.com/elixir-lang/emacs-elixir/pull/195) - highlighting of capitalized modules when used as structs
-* [#192](https://github.com/elixir-lang/emacs-elixir/pull/192) - Fix (error "Lisp nesting exceeds `max-lisp-eval-depth'") which crashes correct indentation
-* [#190](https://github.com/elixir-lang/emacs-elixir/pull/190) - correct indentation for multiclause anonymous functions
-* [#189](https://github.com/elixir-lang/emacs-elixir/pull/189) - Modify indentation rules for one-line functions ending with bitstrings.
-* [#179](https://github.com/elixir-lang/emacs-elixir/pull/179) - Modify syntax highlighting so there is no differentiating between built-in and user-defined modules.
-* [#188](https://github.com/elixir-lang/emacs-elixir/pull/188) - Fix changelog.
-* [#187](https://github.com/elixir-lang/emacs-elixir/pull/187) - Add unresolved test case.
-* [#178](https://github.com/elixir-lang/emacs-elixir/pull/178) - Factor out `cask install` as its own task in Rakefile
+* [#193](https://github.com/elixir-editors/emacs-elixir/pull/193) - fix wrong indentation on empty line between existing code
+* [#195](https://github.com/elixir-editors/emacs-elixir/pull/195) - highlighting of capitalized modules when used as structs
+* [#192](https://github.com/elixir-editors/emacs-elixir/pull/192) - Fix (error "Lisp nesting exceeds `max-lisp-eval-depth'") which crashes correct indentation
+* [#190](https://github.com/elixir-editors/emacs-elixir/pull/190) - correct indentation for multiclause anonymous functions
+* [#189](https://github.com/elixir-editors/emacs-elixir/pull/189) - Modify indentation rules for one-line functions ending with bitstrings.
+* [#179](https://github.com/elixir-editors/emacs-elixir/pull/179) - Modify syntax highlighting so there is no differentiating between built-in and user-defined modules.
+* [#188](https://github.com/elixir-editors/emacs-elixir/pull/188) - Fix changelog.
+* [#187](https://github.com/elixir-editors/emacs-elixir/pull/187) - Add unresolved test case.
+* [#178](https://github.com/elixir-editors/emacs-elixir/pull/178) - Factor out `cask install` as its own task in Rakefile
 
 ## v2.2.1 - 2015/05/19
-* [#186](https://github.com/elixir-lang/emacs-elixir/pull/186) - Remove undocumented failing tests.
-* [#182](https://github.com/elixir-lang/emacs-elixir/pull/182) - Remove redundant local-pair tip for smartparens users
-* [#183](https://github.com/elixir-lang/emacs-elixir/pull/183) - Fix typos in README.
-* [#176](https://github.com/elixir-lang/emacs-elixir/pull/176) - Highlight digits in atoms
-* [#173](https://github.com/elixir-lang/emacs-elixir/pull/173) - Add function to apply `fill-region` in doc strings
-* [#175](https://github.com/elixir-lang/emacs-elixir/pull/175) - Add tips for smartparens users
-* [#177](https://github.com/elixir-lang/emacs-elixir/pull/177) - Prefer Emacs over emacs.
-* [#141](https://github.com/elixir-lang/emacs-elixir/pull/141) - Add documentation line explaining how to edit Elixir templates.
+* [#186](https://github.com/elixir-editors/emacs-elixir/pull/186) - Remove undocumented failing tests.
+* [#182](https://github.com/elixir-editors/emacs-elixir/pull/182) - Remove redundant local-pair tip for smartparens users
+* [#183](https://github.com/elixir-editors/emacs-elixir/pull/183) - Fix typos in README.
+* [#176](https://github.com/elixir-editors/emacs-elixir/pull/176) - Highlight digits in atoms
+* [#173](https://github.com/elixir-editors/emacs-elixir/pull/173) - Add function to apply `fill-region` in doc strings
+* [#175](https://github.com/elixir-editors/emacs-elixir/pull/175) - Add tips for smartparens users
+* [#177](https://github.com/elixir-editors/emacs-elixir/pull/177) - Prefer Emacs over emacs.
+* [#141](https://github.com/elixir-editors/emacs-elixir/pull/141) - Add documentation line explaining how to edit Elixir templates.
 * [Syntax Highlighting] Modules don't start with underscore. This fix corrects the fontification of private function.
 
 ## v2.2.0 2014/12/31
@@ -143,101 +143,101 @@
   * [Deprecated] Add deprecated message for eval and quoted functions.
 
 ## v2.0.2 - 2014/10/29
-  * [#136](https://github.com/elixir-lang/emacs-elixir/pull/136) - Expand def of block operator regex to include non-newlines.
-  * [#137](https://github.com/elixir-lang/emacs-elixir/pull/137) - update rake tasks
-  * [#135](https://github.com/elixir-lang/emacs-elixir/pull/135) - Update README so the MELPA badge points to stable build.
-  * [#133](https://github.com/elixir-lang/emacs-elixir/pull/133) - refine readme
-  * [#134](https://github.com/elixir-lang/emacs-elixir/pull/134) - refine the ability to show the current elixir-mode version
-  * [#132](https://github.com/elixir-lang/emacs-elixir/pull/132) - Added: test coverage with undercover.el
-  * [#131](https://github.com/elixir-lang/emacs-elixir/pull/131) - Fix documentation url
-  * [#127](https://github.com/elixir-lang/emacs-elixir/pull/127) - Add failing test for comment in cond expression (fixed)
-  * [#128](https://github.com/elixir-lang/emacs-elixir/pull/128) - Added: collection of failing tests
-  * [#124](https://github.com/elixir-lang/emacs-elixir/pull/124) - Fixed: Build Status badge
-  * [#123](https://github.com/elixir-lang/emacs-elixir/pull/123) - TravisCI: add-apt-repository and apt-get install fix
-  * [#121](https://github.com/elixir-lang/emacs-elixir/pull/121) - Add TravisCI support
-  * [#122](https://github.com/elixir-lang/emacs-elixir/pull/122) - Remove unused code
+  * [#136](https://github.com/elixir-editors/emacs-elixir/pull/136) - Expand def of block operator regex to include non-newlines.
+  * [#137](https://github.com/elixir-editors/emacs-elixir/pull/137) - update rake tasks
+  * [#135](https://github.com/elixir-editors/emacs-elixir/pull/135) - Update README so the MELPA badge points to stable build.
+  * [#133](https://github.com/elixir-editors/emacs-elixir/pull/133) - refine readme
+  * [#134](https://github.com/elixir-editors/emacs-elixir/pull/134) - refine the ability to show the current elixir-mode version
+  * [#132](https://github.com/elixir-editors/emacs-elixir/pull/132) - Added: test coverage with undercover.el
+  * [#131](https://github.com/elixir-editors/emacs-elixir/pull/131) - Fix documentation url
+  * [#127](https://github.com/elixir-editors/emacs-elixir/pull/127) - Add failing test for comment in cond expression (fixed)
+  * [#128](https://github.com/elixir-editors/emacs-elixir/pull/128) - Added: collection of failing tests
+  * [#124](https://github.com/elixir-editors/emacs-elixir/pull/124) - Fixed: Build Status badge
+  * [#123](https://github.com/elixir-editors/emacs-elixir/pull/123) - TravisCI: add-apt-repository and apt-get install fix
+  * [#121](https://github.com/elixir-editors/emacs-elixir/pull/121) - Add TravisCI support
+  * [#122](https://github.com/elixir-editors/emacs-elixir/pull/122) - Remove unused code
 
 ## v2.0.1 - 2014/09/11
-  * [#119](https://github.com/elixir-lang/emacs-elixir/pull/119) - Fixed: indent-inside-parens
-  * [#117](https://github.com/elixir-lang/emacs-elixir/pull/117) - Fixed: emacs 24.3 tests
-  * [#116](https://github.com/elixir-lang/emacs-elixir/pull/116) - Add "How to run tests" section to CONTRIBUTING.md
-  * [#118](https://github.com/elixir-lang/emacs-elixir/pull/118) - Added: try/rescue rule
-  * [#114](https://github.com/elixir-lang/emacs-elixir/pull/114) - Fixed: run tests interectively for terminal
+  * [#119](https://github.com/elixir-editors/emacs-elixir/pull/119) - Fixed: indent-inside-parens
+  * [#117](https://github.com/elixir-editors/emacs-elixir/pull/117) - Fixed: emacs 24.3 tests
+  * [#116](https://github.com/elixir-editors/emacs-elixir/pull/116) - Add "How to run tests" section to CONTRIBUTING.md
+  * [#118](https://github.com/elixir-editors/emacs-elixir/pull/118) - Added: try/rescue rule
+  * [#114](https://github.com/elixir-editors/emacs-elixir/pull/114) - Fixed: run tests interectively for terminal
 
 ## v2.0.0 - 2014/09/08
-  * [#113](https://github.com/elixir-lang/emacs-elixir/pull/113) - Cask and ert-runner support
-  * [#110](https://github.com/elixir-lang/emacs-elixir/pull/110) - Added: ability to run tests via EVM
-  * [#111](https://github.com/elixir-lang/emacs-elixir/pull/111) - Fixed: elixir-quoted-minor-mode tests for ert-run-tests-interactively
-  * [#108](https://github.com/elixir-lang/emacs-elixir/pull/108) - Fix various issues caused by code followed by inline comments
+  * [#113](https://github.com/elixir-editors/emacs-elixir/pull/113) - Cask and ert-runner support
+  * [#110](https://github.com/elixir-editors/emacs-elixir/pull/110) - Added: ability to run tests via EVM
+  * [#111](https://github.com/elixir-editors/emacs-elixir/pull/111) - Fixed: elixir-quoted-minor-mode tests for ert-run-tests-interactively
+  * [#108](https://github.com/elixir-editors/emacs-elixir/pull/108) - Fix various issues caused by code followed by inline comments
 
 ## v1.5.0 - 2014/08/27
-  * [#103](https://github.com/elixir-lang/emacs-elixir/pull/103) - Add elixir-quoted-minor-mode.
+  * [#103](https://github.com/elixir-editors/emacs-elixir/pull/103) - Add elixir-quoted-minor-mode.
 
 ## v1.4.10 - 2014/08/26
-  * [#102](https://github.com/elixir-lang/emacs-elixir/pull/102) - Add support for syntax highlighting for variable interpolation. Fixes #93
-  * [#101](https://github.com/elixir-lang/emacs-elixir/pull/101) - Fix indentation after inline comment. Fixes #95
+  * [#102](https://github.com/elixir-editors/emacs-elixir/pull/102) - Add support for syntax highlighting for variable interpolation. Fixes #93
+  * [#101](https://github.com/elixir-editors/emacs-elixir/pull/101) - Fix indentation after inline comment. Fixes #95
 
 ## v1.4.9 - 2014/08/25
-  * [#100](https://github.com/elixir-lang/emacs-elixir/pull/100) - Fix indentation in multi-line match expressions. Fixes #98
-  * [#99](https://github.com/elixir-lang/emacs-elixir/pull/99) - Tokenize trailing whitespace properly. Fixes #97
-  * [#96](https://github.com/elixir-lang/emacs-elixir/pull/96) - Remove syntax highlighting for operators.
+  * [#100](https://github.com/elixir-editors/emacs-elixir/pull/100) - Fix indentation in multi-line match expressions. Fixes #98
+  * [#99](https://github.com/elixir-editors/emacs-elixir/pull/99) - Tokenize trailing whitespace properly. Fixes #97
+  * [#96](https://github.com/elixir-editors/emacs-elixir/pull/96) - Remove syntax highlighting for operators.
 
 ## v1.4.8 - 2014/08/19
-  * [#92](https://github.com/elixir-lang/emacs-elixir/pull/92) - Update Rakefile to also run the release.py script. Refs #88.
-  * [#91](https://github.com/elixir-lang/emacs-elixir/pull/91) - Updates to regexes for various lexemes
-  * [#90](https://github.com/elixir-lang/emacs-elixir/pull/90) - Fix bug in atom highlighting.
+  * [#92](https://github.com/elixir-editors/emacs-elixir/pull/92) - Update Rakefile to also run the release.py script. Refs #88.
+  * [#91](https://github.com/elixir-editors/emacs-elixir/pull/91) - Updates to regexes for various lexemes
+  * [#90](https://github.com/elixir-editors/emacs-elixir/pull/90) - Fix bug in atom highlighting.
 
 ## v1.4.7 - 2014/08/18
-  * [#87](https://github.com/elixir-lang/emacs-elixir/pull/87) - Add syntax highlighting for heredocs & failing tests for indentation.
-  * [#85](https://github.com/elixir-lang/emacs-elixir/pull/85) - Improve regex for defmodule highlighting.
-  * [#84](https://github.com/elixir-lang/emacs-elixir/pull/84) - Improve fontification for identifiers.
+  * [#87](https://github.com/elixir-editors/emacs-elixir/pull/87) - Add syntax highlighting for heredocs & failing tests for indentation.
+  * [#85](https://github.com/elixir-editors/emacs-elixir/pull/85) - Improve regex for defmodule highlighting.
+  * [#84](https://github.com/elixir-editors/emacs-elixir/pull/84) - Improve fontification for identifiers.
 
 ## v1.4.6 - 2014/08/18
-  * [#82](https://github.com/elixir-lang/emacs-elixir/pull/82) - Remove broken SMIE rule.
+  * [#82](https://github.com/elixir-editors/emacs-elixir/pull/82) - Remove broken SMIE rule.
 
 ## v1.4.5 - 2014/08/18
-  * [#81](https://github.com/elixir-lang/emacs-elixir/pull/81) - Rewrite token emitting functions
+  * [#81](https://github.com/elixir-editors/emacs-elixir/pull/81) - Rewrite token emitting functions
 
 ## v1.4.4 - 2014/08/18
-  * [#79](https://github.com/elixir-lang/emacs-elixir/pull/79) - Remove erroneous defrecord syntax.
+  * [#79](https://github.com/elixir-editors/emacs-elixir/pull/79) - Remove erroneous defrecord syntax.
 
 ## v1.4.3 - 2014/08/16
-  * [#75](https://github.com/elixir-lang/emacs-elixir/pull/75) - Clean up several minor bugbears in elixir-smie.
-  * [#74](https://github.com/elixir-lang/emacs-elixir/pull/74) - Remove special indentation rules for operators, except booleans.
+  * [#75](https://github.com/elixir-editors/emacs-elixir/pull/75) - Clean up several minor bugbears in elixir-smie.
+  * [#74](https://github.com/elixir-editors/emacs-elixir/pull/74) - Remove special indentation rules for operators, except booleans.
 
 ## v1.4.2 - 2014/08/15
-  * [#73](https://github.com/elixir-lang/emacs-elixir/pull/73) - Fix buggy syntax highlighting behavior involving "?"
-  * [#71](https://github.com/elixir-lang/emacs-elixir/pull/71) - Need two backslashes in regex string.
-  * [#70](https://github.com/elixir-lang/emacs-elixir/pull/70) - Use define-derived-mode to define elixir-mode
-  * [#69](https://github.com/elixir-lang/emacs-elixir/pull/69) - Remove unused variable
+  * [#73](https://github.com/elixir-editors/emacs-elixir/pull/73) - Fix buggy syntax highlighting behavior involving "?"
+  * [#71](https://github.com/elixir-editors/emacs-elixir/pull/71) - Need two backslashes in regex string.
+  * [#70](https://github.com/elixir-editors/emacs-elixir/pull/70) - Use define-derived-mode to define elixir-mode
+  * [#69](https://github.com/elixir-editors/emacs-elixir/pull/69) - Remove unused variable
 
 ## v1.4.1 - 2014/08/11
-  * [#66](https://github.com/elixir-lang/emacs-elixir/pull/66) - Indent correctly after one-liner if/do: statements. Fixes #65
-  * [#64](https://github.com/elixir-lang/emacs-elixir/pull/64) - wrong indentation if space between if and statement
-  * [#63](https://github.com/elixir-lang/emacs-elixir/pull/63) - Correctly indent one-line anon fns AND block fns. Fixes #59
+  * [#66](https://github.com/elixir-editors/emacs-elixir/pull/66) - Indent correctly after one-liner if/do: statements. Fixes #65
+  * [#64](https://github.com/elixir-editors/emacs-elixir/pull/64) - wrong indentation if space between if and statement
+  * [#63](https://github.com/elixir-editors/emacs-elixir/pull/63) - Correctly indent one-line anon fns AND block fns. Fixes #59
 
 ## v1.4.0 - 2014/07/09
-  * [#62](https://github.com/elixir-lang/emacs-elixir/pull/62) - Remove grammar entry causing erroneous alignment to ".". Fixes #49
-  * [#61](https://github.com/elixir-lang/emacs-elixir/pull/61) - Remove "=" & left-assoc opers from "OP" regex. Fixes #18.
-  * [#60](https://github.com/elixir-lang/emacs-elixir/pull/60) - Refactor font face defaults.
-  * [#58](https://github.com/elixir-lang/emacs-elixir/pull/58) - Use string syntax highlighting for regex patterns.
-  * [#57](https://github.com/elixir-lang/emacs-elixir/pull/57) - Add beginnings of font-face testing.
+  * [#62](https://github.com/elixir-editors/emacs-elixir/pull/62) - Remove grammar entry causing erroneous alignment to ".". Fixes #49
+  * [#61](https://github.com/elixir-editors/emacs-elixir/pull/61) - Remove "=" & left-assoc opers from "OP" regex. Fixes #18.
+  * [#60](https://github.com/elixir-editors/emacs-elixir/pull/60) - Refactor font face defaults.
+  * [#58](https://github.com/elixir-editors/emacs-elixir/pull/58) - Use string syntax highlighting for regex patterns.
+  * [#57](https://github.com/elixir-editors/emacs-elixir/pull/57) - Add beginnings of font-face testing.
 
 ## v1.3.1 - 2014/07/05
-  * [#52](https://github.com/elixir-lang/emacs-elixir/pull/52) - Add CLI for running elixir-mode tests.
-  * [#48](https://github.com/elixir-lang/emacs-elixir/pull/48) - Add a SMIE rule function for "def". Fixes #38 and #41
-  * [#50](https://github.com/elixir-lang/emacs-elixir/pull/50) - Remove grammar clause for "fn" terminal. Fixes #7
-  * [#44](https://github.com/elixir-lang/emacs-elixir/pull/44) - sigil % to ~
-  * [#46](https://github.com/elixir-lang/emacs-elixir/pull/46) - Added highlight for unless and Task module
-  * [#45](https://github.com/elixir-lang/emacs-elixir/pull/45) - Highlight defstruct and Actor, Base modules
-  * [#40](https://github.com/elixir-lang/emacs-elixir/pull/40) - IMenu: Show ExUnit tests under heading "Tests".
-  * [#37](https://github.com/elixir-lang/emacs-elixir/pull/37) - Remove needless statement
-  * [#35](https://github.com/elixir-lang/emacs-elixir/pull/35) - Added simple imenu support.
-  * [#32](https://github.com/elixir-lang/emacs-elixir/pull/32) - Properly make variables local
-  * [#31](https://github.com/elixir-lang/emacs-elixir/pull/31) - needed for effective code-navigation via syntax-ppss
-  * [#28](https://github.com/elixir-lang/emacs-elixir/pull/28) - Recognize ? char syntax
-  * [#24](https://github.com/elixir-lang/emacs-elixir/pull/24) - elixir-mode-eval-on-current-buffer binding comment incorrect
-  * [#22](https://github.com/elixir-lang/emacs-elixir/pull/22) - Enhance `elixir-mode-iex` to accept additional arguments
+  * [#52](https://github.com/elixir-editors/emacs-elixir/pull/52) - Add CLI for running elixir-mode tests.
+  * [#48](https://github.com/elixir-editors/emacs-elixir/pull/48) - Add a SMIE rule function for "def". Fixes #38 and #41
+  * [#50](https://github.com/elixir-editors/emacs-elixir/pull/50) - Remove grammar clause for "fn" terminal. Fixes #7
+  * [#44](https://github.com/elixir-editors/emacs-elixir/pull/44) - sigil % to ~
+  * [#46](https://github.com/elixir-editors/emacs-elixir/pull/46) - Added highlight for unless and Task module
+  * [#45](https://github.com/elixir-editors/emacs-elixir/pull/45) - Highlight defstruct and Actor, Base modules
+  * [#40](https://github.com/elixir-editors/emacs-elixir/pull/40) - IMenu: Show ExUnit tests under heading "Tests".
+  * [#37](https://github.com/elixir-editors/emacs-elixir/pull/37) - Remove needless statement
+  * [#35](https://github.com/elixir-editors/emacs-elixir/pull/35) - Added simple imenu support.
+  * [#32](https://github.com/elixir-editors/emacs-elixir/pull/32) - Properly make variables local
+  * [#31](https://github.com/elixir-editors/emacs-elixir/pull/31) - needed for effective code-navigation via syntax-ppss
+  * [#28](https://github.com/elixir-editors/emacs-elixir/pull/28) - Recognize ? char syntax
+  * [#24](https://github.com/elixir-editors/emacs-elixir/pull/24) - elixir-mode-eval-on-current-buffer binding comment incorrect
+  * [#22](https://github.com/elixir-editors/emacs-elixir/pull/22) - Enhance `elixir-mode-iex` to accept additional arguments
 
 ## 1.3.0 (June 24, 2013)
   * Add `elixir-mode-eval-on-region` to evalute Elixir code on the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,8 @@ So you've found a bug or have a great idea for a feature. Here's the steps you
 should take to help get it added/fixed in emacs-elixir
 
 * First, check to see if there's an existing issue/pull request for the
-  bug/feature. All issues are at https://github.com/elixir-lang/emacs-elixir/issues
-  and pull reqs are at https://github.com/elixir-lang/emacs-elixir/pulls.
+  bug/feature. All issues are at https://github.com/elixir-editors/emacs-elixir/issues
+  and pull reqs are at https://github.com/elixir-editors/emacs-elixir/pulls.
 * If there isn't one there, please file an issue. The ideal report includes:
 
   * A description of the problem/suggestion.

--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ This mode is based on the
 
 ## Contributing
 
-Please read [CONTRIBUTING.md](https://github.com/elixir-lang/emacs-elixir/blob/master/CONTRIBUTING.md) for guidelines on how to contribute to this project.
+Please read [CONTRIBUTING.md](https://github.com/elixir-editors/emacs-elixir/blob/master/CONTRIBUTING.md) for guidelines on how to contribute to this project.
 
 ## License
 
 Copyright © 2011-2017 Samuel Tonini, Matt DeBoard, Andreas Fuchs, secondplanet and
-[contributors](https://github.com/elixir-lang/emacs-elixir/contributors).
+[contributors](https://github.com/elixir-editors/emacs-elixir/contributors).
 
 Distributed under the GNU General Public License, version 3
 

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -7,7 +7,7 @@
 ;;          Matt DeBoard
 ;;          Samuel Tonini <tonini.samuel@gmail.com>
 
-;; URL: https://github.com/elixir-lang/emacs-elixir
+;; URL: https://github.com/elixir-editors/emacs-elixir
 ;; Created: Mon Nov 7 2011
 ;; Keywords: languages elixir
 ;; Version: 2.3.1
@@ -45,7 +45,7 @@
   "Major mode for editing Elixir code."
   :prefix "elixir-"
   :group 'languages
-  :link '(url-link :tag "Github" "https://github.com/elixir-lang/emacs-elixir")
+  :link '(url-link :tag "Github" "https://github.com/elixir-editors/emacs-elixir")
   :link '(emacs-commentary-link :tag "Commentary" "elixir-mode"))
 
 (defvar elixir-mode-website-url "http://elixir-lang.org"
@@ -414,7 +414,7 @@ is used to limit the scan."
 (defun elixir-mode-open-github ()
   "Elixir mode open GitHub page."
   (interactive)
-  (browse-url "https://github.com/elixir-lang/emacs-elixir"))
+  (browse-url "https://github.com/elixir-editors/emacs-elixir"))
 
 ;;;###autoload
 (defun elixir-mode-open-elixir-home ()

--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -29,7 +29,7 @@
 (require 'cl-lib)         ; `cl-flet'
 
 ;; HACK: Patch for Emacs 24.3 smie that fix
-;; https://github.com/elixir-lang/emacs-elixir/issues/107.
+;; https://github.com/elixir-editors/emacs-elixir/issues/107.
 ;;
 ;; defadvice is used to change the behavior only for elixir-mode.
 ;; Definition of advice is a definition of corresponding function

--- a/release.py
+++ b/release.py
@@ -25,7 +25,7 @@ def commit_msgs(start_commit, end_commit):
 
     """
     fmt_string = ("'%s%n* [#{pr_num}]"
-                  "(https://github.com/elixir-lang/emacs-elixir/pull/{pr_num}) - %b'")
+                  "(https://github.com/elixir-editors/emacs-elixir/pull/{pr_num}) - %b'")
     return subprocess.check_output([
         "git",
         "log",

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -85,7 +85,7 @@ __aliases__
    (should (eq (elixir-test-face-at 97) nil))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-regex-with-quote ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/23"
+  "https://github.com/elixir-editors/emacs-elixir/issues/23"
   :tags '(fontification syntax-table)
   :expected-result :failed
   (elixir-test-with-temp-buffer
@@ -94,7 +94,7 @@ x = 15"
     (should (eq (elixir-test-face-at 8) 'font-lock-variable-name-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-regex-with-question/1 ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/36"
+  "https://github.com/elixir-editors/emacs-elixir/issues/36"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
       "~r/^matt: (?<ct>\d+)$/mg
@@ -103,7 +103,7 @@ x = 15"
     (should (eq (elixir-test-face-at 25) 'font-lock-variable-name-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-regex-with-question/2 ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/29"
+  "https://github.com/elixir-editors/emacs-elixir/issues/29"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
       "a = \"\" <> \"?\"
@@ -167,7 +167,7 @@ end"
     (should (eq (elixir-test-face-at 91) 'font-lock-keyword-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-end-if-the-last-line-in-a-module-is-a-comment ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/283"
+  "https://github.com/elixir-editors/emacs-elixir/issues/283"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
       "defmodule Foo do
@@ -238,7 +238,7 @@ true_false_nil
     (should (eq (elixir-test-face-at 9) 'elixir-atom-face))
     (should (eq (elixir-test-face-at 10) 'elixir-atom-face)))
 
-  ;; https://github.com/elixir-lang/emacs-elixir/issues/320
+  ;; https://github.com/elixir-editors/emacs-elixir/issues/320
   (elixir-test-with-temp-buffer
    "<<foo::bar>>"
    (should-not (eq (elixir-test-face-at 3) 'elixir-atom-face))))
@@ -296,7 +296,7 @@ some_expr"
    (should (eq (elixir-test-face-at 4) 'font-lock-variable-name-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-assignment-with-singleton ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/245"
+  "https://github.com/elixir-editors/emacs-elixir/issues/245"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "true_false_nil = 1"
@@ -305,7 +305,7 @@ some_expr"
    (should (eq (elixir-test-face-at 12) 'font-lock-variable-name-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-keyword-after-dot ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/250"
+  "https://github.com/elixir-editors/emacs-elixir/issues/250"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "Mix.raise
@@ -356,7 +356,7 @@ end"
    (should (eq (elixir-test-face-at 41) 'font-lock-keyword-face))))
 
 (ert-deftest elixir-mode-syntax-table/string-interpolation-in-words-list ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/263"
+  "https://github.com/elixir-editors/emacs-elixir/issues/263"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "~w(SADD users #{user_id})"
@@ -367,7 +367,7 @@ end"
    (should-not (eq (elixir-test-face-at 25) 'font-lock-comment-face))))
 
 (ert-deftest elixir-mode-syntax-table/quotes-in-sigils ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/265"
+  "https://github.com/elixir-editors/emacs-elixir/issues/265"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "~s/\"/
@@ -445,7 +445,7 @@ foo
    (should     (eq (elixir-test-face-at 21) 'font-lock-type-face))))
 
 (ert-deftest elixir-mode-syntax-table/sigils-in-string ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/275"
+  "https://github.com/elixir-editors/emacs-elixir/issues/275"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "@one 1
@@ -458,7 +458,7 @@ foo
    (should     (eq (elixir-test-face-at 26) 'elixir-atom-face))))
 
 (ert-deftest elixir-mode-syntax-table/sigil-triple-quote ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/286"
+  "https://github.com/elixir-editors/emacs-elixir/issues/286"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "defmodule IEx do
@@ -470,7 +470,7 @@ end
    (should (eq (elixir-test-face-at 33) 'font-lock-string-face))))
 
 (ert-deftest elixir-mode-syntax-table/single-triple-single-quote ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/309"
+  "https://github.com/elixir-editors/emacs-elixir/issues/309"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "defmodule Module do
@@ -487,7 +487,7 @@ end
    (should (eq (elixir-test-face-at 56) 'font-lock-string-face))))
 
 (ert-deftest elixir-mode-syntax-table/comment-out-ignored-var ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/292"
+  "https://github.com/elixir-editors/emacs-elixir/issues/292"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "variable
@@ -514,7 +514,7 @@ end
    (should (eq (elixir-test-face-at 55) 'font-lock-constant-face))))
 
 (ert-deftest elixir-mode-syntax-table/escaped-sigil-delimiter ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/302"
+  "https://github.com/elixir-editors/emacs-elixir/issues/302"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "def player_id(video) do
@@ -546,7 +546,7 @@ end
     )))
 
 (ert-deftest elixir-mode-syntax-table/question-quote ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/185"
+  "https://github.com/elixir-editors/emacs-elixir/issues/185"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "\"\\\"foo\\\"\" |> String.strip(?\")"
@@ -557,7 +557,7 @@ end
    (should-not (eq (elixir-test-face-at 28) 'font-lock-string-face))))
 
 (ert-deftest elixir-mode-syntax-table/ignored-variables-in-pattern-match ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/361"
+  "https://github.com/elixir-editors/emacs-elixir/issues/361"
   :tags '(fontification syntax-table)
   (elixir-test-with-temp-buffer
    "(_1_day = 86_400)
@@ -566,10 +566,10 @@ _1_day"
    (should (eq (elixir-test-face-at 19) 'font-lock-comment-face))))
 
 (ert-deftest elixir-mode-in-docstring ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/355"
+  "https://github.com/elixir-editors/emacs-elixir/issues/355"
   :tags 'fontification
   (elixir-test-with-temp-buffer
-      "# https://github.com/elixir-lang/emacs-elixir/issues/355
+      "# https://github.com/elixir-editors/emacs-elixir/issues/355
 
 @moduledoc \"\"\"
 Everything in here should be gray, including the @moduledoc and triple-quotes
@@ -585,10 +585,10 @@ Everything in here should be gray, including the @doc and triple-quotes
     (should (elixir--docstring-p))))
 
 (ert-deftest elixir-mode-docstring-face ()
-  "https://github.com/elixir-lang/emacs-elixir/issues/355"
+  "https://github.com/elixir-editors/emacs-elixir/issues/355"
   :tags 'fontification
   (elixir-test-with-temp-buffer
-      "# https://github.com/elixir-lang/emacs-elixir/issues/355
+      "# https://github.com/elixir-editors/emacs-elixir/issues/355
 
 @moduledoc \"\"\"
 Everything in here should be gray, including the @moduledoc and triple-quotes

--- a/test/elixir-mode-indentation-test.el
+++ b/test/elixir-mode-indentation-test.el
@@ -756,7 +756,7 @@ end
 
 (elixir-def-indentation-test cond-within-with
                              (:expected-result :failed :tags '(indentation))
-                             ;; https://github.com/elixir-lang/emacs-elixir/issues/319
+                             ;; https://github.com/elixir-editors/emacs-elixir/issues/319
 "
 with(
   foo <-


### PR DESCRIPTION
Simple PR to update the repo URL everywhere. Although GitHub redirects from the old URL to the new one, I think it is not good documentation or, at least, not a good bet to have an old URL spread through the repo.

Whar are your thoughts @Trevoke @axelson ?