### PR TITLE
chore: ignore file generated from running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 ._*
 /.cask/
 /dist/
+*-emacs-elixir-format.ex


### PR DESCRIPTION
An Elixir file is generated while running the test suite. This just adds the file name to .gitignore.