### PR TITLE
@typedoc recognized as heredoc

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -456,7 +456,7 @@ just return nil."
 (defun elixir-mode-fill-doc-string ()
   (interactive)
   (save-excursion
-    (re-search-backward "@\\(?:module\\)?doc +\"\"\"" nil t)
+    (re-search-backward (rx "@" (or "moduledoc" "typedoc" "doc") space "\"\"\"") nil t)
     (re-search-forward "\"\"\"" nil t)
     (set-mark (point))
     (re-search-forward "\"\"\"" nil t)
@@ -495,7 +495,7 @@ just return nil."
     (when pos
       (save-excursion
         (goto-char pos)
-        (and (looking-at "\"\"\"")(looking-back "@moduledoc[ \]+\\|@doc[ \]+"
+        (and (looking-at "\"\"\"")(looking-back (rx "@" (or "moduledoc" "typedoc" "doc") (+ space))
                                                 (line-beginning-position)))))))
 
 (defun elixir-font-lock-syntactic-face-function (state)

--- a/test/elixir-mode-font-test.el
+++ b/test/elixir-mode-font-test.el
@@ -199,6 +199,14 @@ end"
     (should (eq (elixir-test-face-at 2) 'font-lock-builtin-face))
     (should (eq (elixir-test-face-at 3) 'font-lock-string-face))))
 
+(ert-deftest elixir-mode-syntax-table/fontify-heredoc/4 ()
+  :tags '(fontification heredoc syntax-table)
+  (elixir-test-with-temp-buffer
+      "@typedoc \"\"\""
+    (should (eq (elixir-test-face-at 1) 'elixir-attribute-face))
+    (should (eq (elixir-test-face-at 2) 'elixir-attribute-face))
+    (should (eq (elixir-test-face-at 10) 'font-lock-doc-face))))
+
 (ert-deftest elixir-mode-syntax-table/fontify-atoms ()
   :tags '(fontification atom syntax-table)
   (elixir-test-with-temp-buffer


### PR DESCRIPTION
## Background
This fixes #424. This makes `@typedoc` that specify a heredoc look just like `@doc` and `@moduledoc`.

## Screenshot
<img width="519" alt="After" src="https://user-images.githubusercontent.com/16150/88218811-d0f42300-cc1d-11ea-80f9-d30c1eb45c8a.png">
