### PR TITLE
Sigil heredoc support

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -265,7 +265,7 @@ is used to limit the scan."
   (unless (elixir-syntax-in-string-or-comment-p)
     (let ((heredoc-p (save-excursion
                        (goto-char (match-beginning 0))
-                       (looking-at-p "~[sS]\\(?:'''\\|\"\"\"\\)"))))
+                       (looking-at-p "~[BCDELNRSTUbcersw]\\(?:'''\\|\"\"\"\\)"))))
       (unless heredoc-p
         (forward-char 1)
         (let* ((start-delim (char-after (1- (point))))


### PR DESCRIPTION
The syntax highlighting for LiveView with heredocs is broken:
![image](https://user-images.githubusercontent.com/2058614/101193175-31fb2100-362a-11eb-90e3-17bcc6801e2f.png)

This (single character) change make the `~L` sigil support heredocs:
![image](https://user-images.githubusercontent.com/2058614/101193334-6c64be00-362a-11eb-96d7-9a280f5c5c62.png)

Ideally I would like to apply the interpolation face inside of `<% ... %>`, but I'm not really sure how to approach that and this change stands on its own.