### PR TITLE
Highlight atom map keys that end with a newline

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -427,7 +427,7 @@ is used to limit the scan."
      1 font-lock-variable-name-face)
 
     ;; Map keys
-    (,(elixir-rx (group (and identifiers ":")) space)
+    (,(elixir-rx (group (and identifiers ":")) (or space "\n"))
      1 elixir-atom-face)
 
     ;; Pseudovariables

--- a/tests/elixir-mode-font-test.el
+++ b/tests/elixir-mode-font-test.el
@@ -250,7 +250,12 @@ true_false_nil
   ;; https://github.com/elixir-editors/emacs-elixir/issues/320
   (elixir-test-with-temp-buffer
    "<<foo::bar>>"
-   (should-not (eq (elixir-test-face-at 3) 'elixir-atom-face))))
+   (should-not (eq (elixir-test-face-at 3) 'elixir-atom-face)))
+
+  (elixir-test-with-temp-buffer
+   "%{key:
+ a_very_long_value_that_needed_to_wrap}"
+   (should (eq (elixir-test-face-at 3) 'elixir-atom-face))))
 
 (ert-deftest elixir-mode-syntax-table/fontify-interpolation ()
   :tags '(fontification interpolation syntax-table)


### PR DESCRIPTION
Problem
=======

Presently, the atom face is not applied to the syntactic-sugar (flipped colon) atom keys in a map if the value for key is on the next line.

![old_key](https://user-images.githubusercontent.com/2058614/102440527-64275e00-3fee-11eb-8cc3-5871fc56ee7f.png)

Solution
========

Small change for the `rx` to accept either a space or a newline after the key. For whatever reason (probably a good one), newlines are not considered part of the "space" class.

![new_key](https://user-images.githubusercontent.com/2058614/102440582-7f926900-3fee-11eb-9bd8-65c07063973c.png)
