### PR TITLE
chore: update guides with new build system

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ In order to be merged into emacs-elixir, contributions must have the following:
 * A solid patch that:
 
   * is clear.
-  * works across all supported versions of Emacs (24+).
+  * works across all supported versions of Emacs (25+).
   * follows the existing style of the code base.
   * comments included as needed.
 
@@ -58,91 +58,42 @@ substantial time for the all-volunteer team to get to.
 
 ## How to run tests
 
-There are two tools that helps us to test emacs-elixir:
+We use [Eldev](https://github.com/doublep/eldev) as the project management tool and its built-in ERT integration. Our build matrix can be seen in the workflow file in `.github/workflows/ci.yml`. This ensure we run tests in all of our build matrix.
 
-* [Cask](https://github.com/cask/cask) - a project management tool for Emacs that helps automate the package development cycle.
-* [Ert-runner](https://github.com/rejeep/ert-runner.el) - a tool for Emacs projects tested using Ert.
-
-### Emacs Version Manager
-
-Emacs has many versions and currently we support from version 24+. If you want to reproduce a bug/issue on a specific version of Emacs, there are some alternatives like EVM. Here is a setup for EVM. 
-
-To install [EVM](https://github.com/rejeep/evm), run:
-
-```bash
-$ sudo mkdir /usr/local/evm
-$ sudo chown $USER: /usr/local/evm
-$ curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
-$ export PATH="~/.evm/bin:$PATH" # Add it to your .bashrc or analogue
-```
-
-To list all available Emacs versions you can install, run:
-
-```bash
-$ evm list
-```
-
-To install a version (for example `emacs-24.3-bin`), run:
-
-```bash
-$ evm install emacs-24.3-bin
-```
-
-Read more about [EVM](https://github.com/rejeep/evm).
-
-### Cask and ert-runner
-
-To install Cask, run:
-
-```bash
-$ curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
-$ export PATH="~/.cask/bin:$PATH" # Add it to your .bashrc or analogue
-```
-
-To install [Ert-runner](https://github.com/rejeep/ert-runner.el), run:
-
-```bash
-$ cd path/to/emacs-elixir
-$ cask install # install ert-runner
-$ EMACS=`evm bin emacs-24.3-bin` cask install # install ert-runner for Emacs 24.3
-```
+Read more about Eldev in its home page.
 
 #### Examples of usage
 
 * Run all tests:
 
 ```bash
-$ cask exec ert-runner
+$ eldev test
 ```
 
-* Run all tests for Emacs 24.3:
+* Check dependencies
 
 ```bash
-$ EMACS=`evm bin emacs-24.3-bin` cask exec ert-runner
+$ eldev deps
 ```
-
-Run all tests which are tagged `fontification`:
 
 ```bash
-$ cask exec ert-runner -t fontification
+$ eldev deps test
 ```
 
-Run all tests with `elixir-smie-verbose-p` equal to `t`:
+* Run linters
 
 ```bash
-$ cask exec ert-runner --verbose
+$ eldev lint
 ```
 
-Run all tests interactively:
+* Compile project (byte compilation)
 
 ```bash
-$ cask exec ert-runner --win
+$ eldev compile
 ```
 
-Run all tests which are tagged `fontification` for Emacs 24.3 interactively:
+* Clean-up, for example, after compilation
 
 ```bash
-$ EMACS=`evm bin emacs-24.3-bin` cask exec ert-runner -t fontification --win
+$ eldev clean
 ```
-
-Read more about [Cask](https://github.com/cask/cask) and [Ert-runner](https://github.com/rejeep/ert-runner.el).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![License GPL 3][badge-license]](http://www.gnu.org/licenses/gpl-3.0.txt)
-[![Build Status](https://travis-ci.org/elixir-editors/emacs-elixir.svg?branch=master)](https://travis-ci.org/elixir-editors/emacs-elixir)
+[![Build Status](https://github.com/elixir-editors/emacs-elixir/actions/workflows/ci.yml/badge.svg)](https://github.com/elixir-editors/emacs-elixir/actions)
 [![MELPA Stable](http://stable.melpa.org/packages/elixir-mode-badge.svg)](http://stable.melpa.org/#/elixir-mode)
 [![MELPA](http://melpa.org/packages/elixir-mode-badge.svg)](http://melpa.org/#/elixir-mode)
 
@@ -56,15 +56,6 @@ obtaining `Elixir-Mode`, as the `master` branch is normally quite stable and
 
 With the most recent builds of Emacs, you can pin `Elixir-Mode` to always
 use MELPA Stable by adding this to your Emacs initialization:
-
-```el
-(add-to-list 'package-pinned-packages '(elixir-mode . "melpa-stable") t)
-```
-
-### Via el-get
-
-[el-get](https://github.com/dimitri/el-get) is another popular package manager for Emacs. If you're an el-get
-user just do <kbd>M-x el-get-install [RET] elixir-mode [RET]</kbd>.
 
 ### Manual
 


### PR DESCRIPTION
Updated README and CONTRIBUTING with the new build system and setup.

I took some liberties and will happily change if it seems not good. 

1. Removed EVM instructions
2. Removed el-get installation instructions 

1 is because I think most people don't use it outside CI systems anyway. I may be wrong though. Perhaps a docker setup to run tests in a pristine Emacs would be better here but I haven't set all that up yet.

2 is because it seemed weird to have `el-get` there without other alternatives. I thought that we should leave only default installation instructions and not custom ones. If we were to add custom ones than we should at least provide a few other options.