### PR TITLE
Add font-lock to arrows

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -182,6 +182,7 @@
                                  (zero-or-more (any "A-Z" "a-z" "_" "0-9"))))
                            (optional (or "!" "?"))
                            symbol-end))
+      (arrows . ,(rx (or "->" "<-" "=>" "|>")))
       (pseudo-var . ,(rx symbol-start
                          (optional (or "%" "&"))
                          (or "_" "__MODULE__" "__DIR__" "__ENV__" "__CALLER__"
@@ -434,6 +435,10 @@ is used to limit the scan."
     ;; Pseudovariables
     (,(elixir-rx (group pseudo-var))
      1 font-lock-constant-face)
+
+    ;; Arrows
+    (,(elixir-rx (group arrows))
+     1 font-lock-keyword-face)
 
     ;; Code points
     (,(elixir-rx (group code-point))

--- a/tests/elixir-mode-font-test.el
+++ b/tests/elixir-mode-font-test.el
@@ -579,6 +579,31 @@ _1_day"
    (should (eq (elixir-test-face-at 2) 'font-lock-comment-face))
    (should (eq (elixir-test-face-at 19) 'font-lock-comment-face))))
 
+(ert-deftest elixir-mode-syntax-table/arrows ()
+  :tags '(fontification syntax-table)
+
+  (elixir-test-with-temp-buffer
+   "with {:ok, _} <- SomeModule.call(),
+         :ok <- OtherModule.call() do
+      :ok
+    end"
+   (should (eq (elixir-test-face-at 15) 'font-lock-keyword-face))
+   (should (eq (elixir-test-face-at 50) 'font-lock-keyword-face)))
+
+  (elixir-test-with-temp-buffer
+   "%{
+      \"\"foo\"\" => \"bar\"
+    }"
+   (should (eq (elixir-test-face-at 18) 'font-lock-keyword-face)))
+
+  (elixir-test-with-temp-buffer
+   "[] |> IO.inspect()"
+   (should (eq (elixir-test-face-at 4) 'font-lock-keyword-face)))
+
+  (elixir-test-with-temp-buffer
+   "a = fn x -> x end"
+   (should (eq (elixir-test-face-at 10) 'font-lock-keyword-face))))
+
 (ert-deftest elixir-mode-in-docstring ()
   "https://github.com/elixir-editors/emacs-elixir/issues/355"
   :tags 'fontification


### PR DESCRIPTION
Big `with` constructs and function pipelines are hard to follow, because arrows are not highlighted in any form. 
This adds font-locking for them