### PR TITLE
Enable elixir-mode by default when opening `mix.lock` file.

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -579,7 +579,8 @@ just return nil."
 (progn
   (add-to-list 'auto-mode-alist '("\\.elixir\\'" . elixir-mode))
   (add-to-list 'auto-mode-alist '("\\.ex\\'" . elixir-mode))
-  (add-to-list 'auto-mode-alist '("\\.exs\\'" . elixir-mode)))
+  (add-to-list 'auto-mode-alist '("\\.exs\\'" . elixir-mode))
+  (add-to-list 'auto-mode-alist '("mix\\.lock" . elixir-mode)))
 
 (provide 'elixir-mode)
 


### PR DESCRIPTION
Closes #480