### PR TITLE
Bump otp and elixir versions for ci testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     strategy:
       matrix:
         emacs_version: ['27.1', '26.3', '25.2']
-        otp: ['21.3', '23.2']
-        elixir: ['1.8.2', '1.11.4']
+        otp: ['22.3', '23.2', '24.2']
+        elixir: ['1.9.4', '1.11.4', '1.13.1']
 
     steps:
       - name: Setup Emacs


### PR DESCRIPTION
Adding missing Elixir 1.13 and otp 24. Elixir 1.8 is not supported anymore, so removed together with otp 21.

https://hexdocs.pm/elixir/1.13.1/compatibility-and-deprecations.html