### PR TITLE
fix(tests): remove duplicated tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,13 @@ on:
 
 jobs:
   test:
-    name: mix test (Emacs ${{matrix.emacs_version}} | Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
+    name: test (Emacs ${{matrix.emacs_version}} | Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: ['27.1', '26.3', '25.2']
-        otp: ['21.3', '23.2']
-        elixir: ['1.8.2', '1.11.4']
+        emacs_version: ['27.2', '26.3', '25.3', 'snapshot']
+        otp: ['23.3']
+        elixir: ['1.8.2', '1.11.4', '1.13.3']
 
     steps:
       - name: Setup Emacs

--- a/README.md
+++ b/README.md
@@ -133,6 +133,11 @@ Alternatively, if you want to use `ruby-end-mode`, you can add the following to 
                (ruby-end-mode +1)))
 ```
 
+## Notes
+
+This package is tested only with a single version of OTP and 3 versions of Elixir. Please, always report versions
+ (Emacs, Elixir and Erlang/OTP) when raising issues.
+
 ## Elixir Tooling Integration
 
 If you looking for elixir tooling integration for Emacs, check: [alchemist.el](https://github.com/tonini/alchemist.el)

--- a/tests/elixir-mode-helper-test.el
+++ b/tests/elixir-mode-helper-test.el
@@ -17,7 +17,8 @@ defmodule Module.Name do
 
 end")
             (goto-line 7)
-            (elixir-smie--heredoc-at-current-point-p)))
+            (elixir-smie--heredoc-at-current-point-p)
+            ))
   (should (not (with-temp-buffer
                  (elixir-mode)
                  (insert "
@@ -44,8 +45,7 @@ defmodule Module.Name do
   end
 end")
                    (goto-line 4)
-                   (elixir-smie--previous-line-indentation))))
-  )
+                   (elixir-smie--previous-line-indentation)))))
 
 
 (ert-deftest check-if-previous-line-blank ()
@@ -72,82 +72,6 @@ defmodule Module.Name do
 end")
             (goto-line 4)
             (elixir-smie--previous-line-empty-p))))
-
-
-;;; elixir-mode-helper-test.el --- Tests for helper functions
-
-;;; Code:
-
-(ert-deftest check-if-currently-inside-heredoc ()
-  (should (with-temp-buffer
-            (elixir-mode)
-            (insert "
-defmodule Module.Name do
-
-  @moduledoc \"\"\"
-  ## Examples
-
-  ....
-  \"\"\"
-
-end")
-            (goto-line 7)
-            (elixir-smie--heredoc-at-current-point-p)))
-  (should (not (with-temp-buffer
-                 (elixir-mode)
-                 (insert "
-defmodule Module.Name do
-
-  @moduledoc \"\"\"
-  ## Examples
-
-  ....
-  \"\"\"
-
-end")
-                 (goto-line 3)
-                 (elixir-smie--heredoc-at-current-point-p)))))
-
-(ert-deftest get-previous-line-indentation ()
-  (should (equal 2
-                 (with-temp-buffer
-                   (elixir-mode)
-                   (insert "
-defmodule Module.Name do
-  def what do
-    1 + 1
-  end
-end")
-                   (goto-line 4)
-                   (elixir-smie--previous-line-indentation))))
-  )
-
-
-(ert-deftest check-if-previous-line-blank ()
-  (should (not (with-temp-buffer
-                 (elixir-mode)
-                 (insert "
-defmodule Module.Name do
-
-  def what do
-    1 + 1
-  end
-end")
-                 (goto-line 3)
-                 (elixir-smie--previous-line-empty-p))))
-  (should (with-temp-buffer
-            (elixir-mode)
-            (insert "
-defmodule Module.Name do
-
-
-  def what do
-    1 + 1
-  end
-end")
-            (goto-line 4)
-            (elixir-smie--previous-line-empty-p))))
-
 
 (ert-deftest test-current-line-contains-built-in-keyword ()
   (should (not (with-temp-buffer


### PR DESCRIPTION
This breaks on Emacs master (as of currently: 29). ERT now breaks if run on Emacs 29.

Also, I've updated the build to ONLY use a single OTP version (as we are not really testing BEAM code here but only syntax). As I've added Elixir 1.13 the number of tests in the matrix remains the same.