### PR TITLE
chore(cleanup): remove Emacs 24 hack not supported anymore

### DIFF
--- a/elixir-smie.el
+++ b/elixir-smie.el
@@ -28,45 +28,6 @@
 (require 'smie)           ; Simple minded indentation engine
 (require 'cl-lib)         ; `cl-flet'
 
-;; HACK: Patch for Emacs 24.3 smie that fix
-;; https://github.com/elixir-editors/emacs-elixir/issues/107.
-;;
-;; defadvice is used to change the behavior only for elixir-mode.
-;; Definition of advice is a definition of corresponding function
-;; in Emacs 24.4.
-(when (and (= 24 emacs-major-version)
-           (= 3  emacs-minor-version))
-  (defadvice smie-rule-parent (around elixir-mode-patch activate)
-    (if (not (eq major-mode 'elixir-mode))
-        (progn ad-do-it)
-      (setq ad-return-value
-            (save-excursion
-              (goto-char (cadr (smie-indent--parent)))
-              (cons 'column
-                    (+ (or offset 0)
-                       (smie-indent-virtual)))))))
-
-  (defadvice smie-indent-comment (around elixir-mode-patch activate)
-    (if (not (eq major-mode 'elixir-mode))
-        (progn ad-do-it)
-      (setq ad-return-value
-            (and (smie-indent--bolp)
-                 (let ((pos (point)))
-                   (save-excursion
-                     (beginning-of-line)
-                     (and (re-search-forward comment-start-skip (line-end-position) t)
-                          (eq pos (or (match-end 1) (match-beginning 0))))))
-                 (save-excursion
-                   (forward-comment (point-max))
-                   (skip-chars-forward " \t\r\n")
-                   (unless
-                       (save-excursion
-                         (let ((next (funcall smie-forward-token-function)))
-                           (or (if (zerop (length next))
-                                   (or (eobp) (eq (car (syntax-after (point))) 5)))
-                               (rassoc next smie-closer-alist))))
-                     (smie-indent-calculate))))))))
-
 ;; In Emacs 27, ppss became a structure and has proper accessors.
 
 (defalias 'elixir-ppss-depth


### PR DESCRIPTION
Since we are only building for 25+ we can remove this now. This specific hack was only for version 24.3 (veeeery specific).