### PR TITLE
WIP: Add treesit font-lock support

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -575,25 +575,18 @@ just return nil."
       (progn
         (require 'elixir-tree-sitter)
 
-        (setq-local treesit-mode-supported t)
-        (setq-local treesit-required-languages '(elixir))
-        ;; (setq-local treesit-simple-indent-rules elixir--treesit-indent-rules)
-
         ;; Font-lock.
         (setq-local treesit-font-lock-settings elixir--treesit-font-lock-settings)
         (setq-local treesit-font-lock-feature-list '((minimal) (moderate) (full)))
 
-
         (setq-local treesit-imenu-function #'elixir--imenu-treesit-create-index)
 
-
-        ;; (setq-local beginning-of-defun-function 'elixir--treesit-beginning-of-defun)
-        ;; (setq-local end-of-defun-function 'elixir--treesit-end-of-defun)
-
+        ;; TODO: set to (treesit-ready-p 'elixir-mode 'elixir)
+        ;; but leaving nil so it assumes true while WIP
         (cond
-         ((treesit-ready-p '(elixir))
-          (treesit-mode)
-          (treesit-font-lock-enable))
+         ((treesit-ready-p nil 'elixir)
+          (treesit-major-mode-setup))
+
          (t
           (message "Tree-sitter for Elixir isn't available"))))))
 

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -39,6 +39,7 @@
 (require 'easymenu)           ; Elixir Mode menu definition
 (require 'elixir-smie)        ; Syntax and indentation support
 (require 'elixir-format)      ; Elixir Format functions
+(require 'elixir-tree-sitter) ; Elixir tree-sitter support
 
 (defgroup elixir nil
   "Major mode for editing Elixir code."
@@ -58,6 +59,13 @@
 (defcustom elixir-mode-hook nil
   "Hook that runs when switching to major mode"
   :type 'hook)
+
+(defcustom elixir-use-tree-sitter t
+  "If non-nil, `elixir-mode' tries to use tree-sitter.
+Currently `elixir-mode' uses tree-sitter for font-locking, imenu,
+and movement functions."
+  :type 'boolean
+  :version "29.1")
 
 (defvar elixir-mode-map
   (let ((map (make-sparse-keymap)))
@@ -567,11 +575,23 @@ just return nil."
   "Major mode for editing Elixir code.
 
 \\{elixir-mode-map}"
+
+  (if (and elixir-use-tree-sitter
+           (treesit-can-enable-p))
+      (progn
+        (setq-local font-lock-keywords-only t)
+        (setq-local treesit-font-lock-feature-list
+                    '((basic) (moderate) (elaborate)))
+        (setq-local treesit-font-lock-settings
+                    elixir--treesit-settings)
+        (treesit-font-lock-enable))
   (setq-local font-lock-defaults
               '(elixir-font-lock-keywords
                 nil nil nil nil
                 (font-lock-syntactic-face-function
-                 . elixir-font-lock-syntactic-face-function)))
+                 . elixir-font-lock-syntactic-face-function))))
+
+
   (setq-local comment-start "# ")
   (setq-local comment-end "")
   (setq-local comment-start-skip "#+ *")

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -575,8 +575,8 @@ just return nil."
            elixir-use-tree-sitter)
       (progn
         (require 'elixir-tree-sitter)
-        (treesit-can-enable-p))))
-
+        (treesit-can-enable-p)
+        (treesit-language-available-p 'elixir))))
 
 ;;;###autoload
 (define-derived-mode elixir-mode prog-mode "Elixir"

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -578,17 +578,22 @@ just return nil."
         (setq-local treesit-mode-supported t)
         (setq-local treesit-required-languages '(elixir))
         ;; (setq-local treesit-simple-indent-rules elixir--treesit-indent-rules)
+
+        ;; Font-lock.
         (setq-local treesit-font-lock-settings elixir--treesit-font-lock-settings)
         (setq-local treesit-font-lock-feature-list '((minimal) (moderate) (full)))
 
+
         (setq-local treesit-imenu-function #'elixir--imenu-treesit-create-index)
+
 
         ;; (setq-local beginning-of-defun-function 'elixir--treesit-beginning-of-defun)
         ;; (setq-local end-of-defun-function 'elixir--treesit-end-of-defun)
 
         (cond
          ((treesit-ready-p '(elixir))
-          (treesit-mode))
+          (treesit-mode)
+          (treesit-font-lock-enable))
          (t
           (message "Tree-sitter for Elixir isn't available"))))))
 
@@ -599,28 +604,34 @@ just return nil."
 
 \\{elixir-mode-map}"
 
-  (setq-local font-lock-defaults
-              '(elixir-font-lock-keywords
-                nil nil nil nil
-                (font-lock-syntactic-face-function
-                 . elixir-font-lock-syntactic-face-function)))
+  ;; (setq-local font-lock-defaults
+  ;;             '(elixir-font-lock-keywords
+  ;;               nil nil nil nil
+  ;;               (font-lock-syntactic-face-function
+  ;;                . elixir-font-lock-syntactic-face-function)))
 
+
+  (setq-local font-lock-keywords-only t)
   (setq-local comment-start "# ")
   (setq-local comment-end "")
   (setq-local comment-start-skip "#+ *")
   (setq-local comment-use-syntax t)
+
   (setq-local syntax-propertize-function #'elixir-syntax-propertize-function)
-  (setq-local imenu-generic-expression elixir-imenu-generic-expression)
 
-  (setq-local beginning-of-defun-function #'elixir-beginning-of-defun)
-  (setq-local end-of-defun-function #'elixir-end-of-defun)
+  ;; (setq-local imenu-generic-expression elixir-imenu-generic-expression)
 
-  (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules
-              :forward-token 'elixir-smie-forward-token
-              :backward-token 'elixir-smie-backward-token)
+  ;; (setq-local beginning-of-defun-function #'elixir-beginning-of-defun)
+  ;; (setq-local end-of-defun-function #'elixir-end-of-defun)
+
+  ;; (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules
+  ;;             :forward-token 'elixir-smie-forward-token
+  ;;             :backward-token 'elixir-smie-backward-token)
   ;; https://github.com/elixir-editors/emacs-elixir/issues/363
   ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=35496
-  (setq-local smie-blink-matching-inners nil)
+  ;; (setq-local smie-blink-matching-inners nil)
+
+  (setq-local font-lock-keywords-only t)
 
   (elixir--treesit-setup))
 

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -577,7 +577,12 @@ just return nil."
 
         ;; Font-lock.
         (setq-local treesit-font-lock-settings elixir--treesit-font-lock-settings)
-        (setq-local treesit-font-lock-feature-list '((minimal) (moderate) (full)))
+        (setq-local treesit-font-lock-feature-list
+              '(( comment string )
+                ( keyword unary-operator operator)
+                ( call constant )
+                ( sigil string-escape)
+                ( string-interpolation )))
 
         (setq-local treesit-imenu-function #'elixir--imenu-treesit-create-index)
 

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -571,29 +571,25 @@ just return nil."
 
 (defun elixir--treesit-setup ()
   "Ensure tree-sitter can be used."
-  (if (and (<= 29 emacs-major-version))
-      (progn
-        (require 'elixir-tree-sitter)
+  (progn
+    (require 'elixir-tree-sitter)
 
-        ;; Font-lock.
-        (setq-local treesit-font-lock-settings elixir--treesit-font-lock-settings)
-        (setq-local treesit-font-lock-feature-list
-              '(( comment string )
-                ( keyword unary-operator operator)
-                ( call constant )
-                ( sigil string-escape)
-                ( string-interpolation )))
+    (setq-local treesit-mode-supported t)
+    (setq-local treesit-required-languages '(elixir))
+    (setq-local treesit-font-lock-settings elixir--treesit-font-lock-settings)
+    (setq-local treesit-font-lock-feature-list
+                '(( comment string )
+                  ( keyword unary-operator operator doc)
+                  ( call constant )
+                  ( sigil string-escape)
+                  ( string-interpolation )))
 
-        (setq-local treesit-imenu-function #'elixir--imenu-treesit-create-index)
-
-        ;; TODO: set to (treesit-ready-p 'elixir-mode 'elixir)
-        ;; but leaving nil so it assumes true while WIP
-        (cond
-         ((treesit-ready-p nil 'elixir)
-          (treesit-major-mode-setup))
-
-         (t
-          (message "Tree-sitter for Elixir isn't available"))))))
+    (setq-local treesit-imenu-function #'elixir--imenu-treesit-create-index)
+    (cond
+     ((treesit-ready-p 'elixir)
+      (treesit-major-mode-setup))
+     (t
+      (message "Tree-sitter for Elixir isn't available")))))
 
 ;;;###autoload
 (define-derived-mode elixir-mode prog-mode "Elixir"
@@ -602,14 +598,6 @@ just return nil."
 
 \\{elixir-mode-map}"
 
-  ;; (setq-local font-lock-defaults
-  ;;             '(elixir-font-lock-keywords
-  ;;               nil nil nil nil
-  ;;               (font-lock-syntactic-face-function
-  ;;                . elixir-font-lock-syntactic-face-function)))
-
-
-  (setq-local font-lock-keywords-only t)
   (setq-local comment-start "# ")
   (setq-local comment-end "")
   (setq-local comment-start-skip "#+ *")
@@ -617,21 +605,20 @@ just return nil."
 
   (setq-local syntax-propertize-function #'elixir-syntax-propertize-function)
 
-  ;; (setq-local imenu-generic-expression elixir-imenu-generic-expression)
+  (setq-local imenu-generic-expression elixir-imenu-generic-expression)
 
-  ;; (setq-local beginning-of-defun-function #'elixir-beginning-of-defun)
-  ;; (setq-local end-of-defun-function #'elixir-end-of-defun)
+  (setq-local beginning-of-defun-function #'elixir-beginning-of-defun)
+  (setq-local end-of-defun-function #'elixir-end-of-defun)
 
-  ;; (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules
-  ;;             :forward-token 'elixir-smie-forward-token
-  ;;             :backward-token 'elixir-smie-backward-token)
+  (smie-setup elixir-smie-grammar 'verbose-elixir-smie-rules
+              :forward-token 'elixir-smie-forward-token
+              :backward-token 'elixir-smie-backward-token)
   ;; https://github.com/elixir-editors/emacs-elixir/issues/363
   ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=35496
-  ;; (setq-local smie-blink-matching-inners nil)
+  (setq-local smie-blink-matching-inners nil)
 
-  (setq-local font-lock-keywords-only t)
-
-  (elixir--treesit-setup))
+  (if (<= 29 emacs-major-version)
+      (elixir--treesit-setup)))
 
 ;; Invoke elixir-mode when appropriate
 

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -39,7 +39,6 @@
 (require 'easymenu)           ; Elixir Mode menu definition
 (require 'elixir-smie)        ; Syntax and indentation support
 (require 'elixir-format)      ; Elixir Format functions
-(require 'elixir-tree-sitter) ; Elixir tree-sitter support
 
 (defgroup elixir nil
   "Major mode for editing Elixir code."
@@ -60,7 +59,7 @@
   "Hook that runs when switching to major mode"
   :type 'hook)
 
-(defcustom elixir-use-tree-sitter t
+(defcustom elixir-use-tree-sitter nil
   "If non-nil, `elixir-mode' tries to use tree-sitter.
 Currently `elixir-mode' uses tree-sitter for font-locking, imenu,
 and movement functions."
@@ -570,14 +569,22 @@ just return nil."
     ["Elixir homepage" elixir-mode-open-elixir-home]
     ["About" elixir-mode-version]))
 
+(defun elixir--use-tree-sitter ()
+  "Ensure tree-sitter can be used."
+  (if (and (<= 29 emacs-major-version)
+           elixir-use-tree-sitter)
+      (progn
+        (require 'elixir-tree-sitter)
+        (treesit-can-enable-p))))
+
+
 ;;;###autoload
 (define-derived-mode elixir-mode prog-mode "Elixir"
   "Major mode for editing Elixir code.
 
 \\{elixir-mode-map}"
 
-  (if (and elixir-use-tree-sitter
-           (treesit-can-enable-p))
+  (if (elixir--use-tree-sitter)
       (progn
         (setq-local font-lock-keywords-only t)
         (setq-local treesit-font-lock-feature-list

--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -195,7 +195,7 @@ and movement functions."
                          (or "_" "__MODULE__" "__DIR__" "__ENV__" "__CALLER__"
                              "__block__" "__aliases__")
                          symbol-end))
-      (sigils . ,(rx "~" (or "B" "C" "D" "E" "L" "N" "R" "S" "T" "U" "b" "c" "e" "r" "s" "w")))))
+      (sigils . ,(rx "~" (or "B" "C" "D" "E" "H" "L" "N" "R" "S" "T" "U" "b" "c" "e" "r" "s" "w")))))
 
   (defmacro elixir-rx (&rest sexps)
     (let ((rx-constituents (append elixir-rx-constituents rx-constituents)))

--- a/elixir-tree-sitter.el
+++ b/elixir-tree-sitter.el
@@ -1,0 +1,325 @@
+;;; elixir-tree-sitter.el --- Tree sitter for elixir-mode
+
+;; Copyright 2022 Wilhelm H Kirschbaum
+
+;; This file is not a part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, write to the Free Software
+;; Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+;;; Commentary:
+
+;;  Tree sitter for elixir-mode
+
+;;; Code:
+
+(require 'treesit nil t)
+
+;; Custom faces match highlights.scm as close as possible
+;; to help with updates
+
+(defface elixir-font-keyword-face
+  '((t (:inherit font-lock-keyword-face)))
+  "For use with @keyword tag.")
+
+(defface elixir-font-comment-doc-face
+  '((t (:inherit font-lock-doc-face)))
+  "For use with @comment.doc tag.")
+
+(defface elixir-font-comment-doc-identifier-face
+  '((t (:inherit font-lock-doc-face)))
+  "For use with @comment.doc tag.")
+
+(defface elixir-font-comment-doc-attribute-face
+  '((t (:inherit font-lock-doc-face)))
+  "For use with @comment.doc.__attribute__ tag.")
+
+(defface elixir-font-attribute-face
+  '((t (:inherit font-lock-preprocessor-face)))
+  "For use with @attribute tag.")
+
+(defface elixir-font-operator-face
+  '((t (:inherit default)))
+  "For use with @operator tag.")
+
+(defface elixir-font-constant-face
+  '((t (:inherit font-lock-constant-face)))
+  "For use with @constant tag.")
+
+(defface elixir-font-number-face
+  '((t (:inherit default)))
+  "For use with @number tag.")
+
+(defface elixir-font-module-face
+  '((t (:inherit font-lock-type-face)))
+  "For use with @module tag.")
+
+(defface elixir-font-punctuation-face
+  '((t (:inherit font-lock-keyword-face)))
+  "For use with @punctuation tag.")
+
+(defface elixir-font-punctuation-delimiter-face
+  '((t (:inherit font-lock-keyword-face)))
+  "For use with @punctuation.delimiter tag.")
+
+(defface elixir-font-punctuation-bracket-face
+  '((t (:inherit font-lock-keyword-face)))
+  "For use with @punctuation.bracket.")
+
+(defface elixir-font-punctuation-special-face
+  '((t (:inherit font-lock-variable-name-face)))
+  "For use with @punctuation.special tag.")
+
+(defface elixir-font-embedded-face
+  '((t (:inherit default)))
+  "For use with @embedded tag.")
+
+(defface elixir-font-string-face
+  '((t (:inherit font-lock-string-face)))
+  "For use with @string tag.")
+
+(defface elixir-font-string-escape-face
+  '((t (:inherit font-lock-regexp-grouping-backslash)))
+  "For use with Reserved keywords.")
+
+(defface elixir-font-string-regex-face
+  '((t (:inherit font-lock-string-face)))
+  "For use with @string.regex tag.")
+
+(defface elixir-font-string-special-face
+  '((t (:inherit font-lock-string-face)))
+  "For use with @string.special tag.")
+
+(defface elixir-font-string-special-symbol-face
+  '((t (:inherit font-lock-builtin-face)))
+  "For use with @string.special.symbol tag.")
+
+(defface elixir-font-function-face
+  '((t (:inherit font-lock-function-name-face)))
+  "For use with @function tag.")
+
+(defface elixir-font-sigil-name-face
+  '((t (:inherit font-lock-string-face)))
+  "For use with @__name__ tag.")
+
+(defface elixir-font-variable-face
+  '((t (:inherit default)))
+  "For use with @variable tag.")
+
+(defface elixir-font-constant-builtin-face
+  '((t (:inherit font-lock-keyword-face)))
+  "For use with @constant.builtin tag.")
+
+(defface elixir-font-comment-face
+  '((t (:inherit font-lock-comment-face)))
+  "For use with @comment tag.")
+
+(defface elixir-font-comment-unused-face
+  '((t (:inherit font-lock-comment-face)))
+  "For use with @comment.unused tag.")
+
+(defface elixir-font-error-face
+  '((t (:inherit error)))
+  "For use with @comment.unused tag.")
+
+;; Faces end
+
+(defconst elixir--definition-keywords
+  '("def" "defdelegate" "defexception" "defguard" "defguardp" "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp" "defoverridable" "defp" "defprotocol" "defstruct"))
+
+(defconst elixir--definition-keywords-re
+  (concat "^" (regexp-opt elixir--definition-keywords) "$"))
+
+(defconst elixir--kernel-keywords
+  '("alias" "case" "cond" "else" "for" "if" "import" "quote" "raise" "receive" "require" "reraise" "super" "throw" "try" "unless" "unquote" "unquote_splicing" "use" "with"))
+
+(defconst elixir--kernel-keywords-re
+  (concat "^" (regexp-opt elixir--kernel-keywords) "$"))
+
+(defconst elixir--builtin-keywords
+  '("__MODULE__" "__DIR__" "__ENV__" "__CALLER__" "__STACKTRACE__"))
+
+(defconst elixir--builtin-keywords-re
+  (concat "^" (regexp-opt elixir--builtin-keywords) "$"))
+
+
+(defconst elixir--doc-keywords
+  '("moduledoc" "typedoc" "doc"))
+
+(defconst elixir--doc-keywords-re
+  (concat "^" (regexp-opt elixir--doc-keywords) "$"))
+
+(defconst elixir--reserved-keywords
+  '("when" "and" "or" "not" "in"
+   "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
+
+(defconst elixir--reserved-keywords
+  '("when" "and" "or" "not" "in"
+   "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
+
+(defconst elixir--reserved-keywords-re
+  (concat "^" (regexp-opt elixir--reserved-keywords) "$"))
+
+(defconst elixir--reserved-keywords-vector
+  (apply #'vector elixir--reserved-keywords))
+
+;; reference:
+;; https://github.com/elixir-lang/tree-sitter-elixir/blob/main/queries/highlights.scm
+(defvar elixir--treesit-settings
+  (treesit-font-lock-rules
+   :language 'elixir
+   :feature 'basic
+   `(
+     (comment) @elixir-font-comment-face
+
+     ,elixir--reserved-keywords-vector @elixir-font-keyword-face
+
+     (unary_operator
+      operator: "@" @elixir-font-comment-doc-attribute-face
+      operand: (call
+                target: (identifier) @elixir-font-comment-doc-identifier-face
+                ;; arguments can be optional, but not sure how to specify
+                ;; so adding another entry without arguments
+                ;; if we don't handle then we don't apply font
+                ;; and the non doc fortification query will take specify
+                ;; a more specific font which takes precedence
+                (arguments
+                 [
+                  (string) @elixir-font-comment-doc-face
+                  (charlist) @elixir-font-comment-doc-face
+                  (sigil) @elixir-font-comment-doc-face
+                  (boolean) @elixir-font-comment-doc-face
+                  ]))
+      (:match ,elixir--doc-keywords-re @elixir-font-comment-doc-identifier-face))
+
+     (unary_operator
+      operator: "@" @elixir-font-comment-doc-attribute-face
+      operand: (call
+                target: (identifier) @elixir-font-comment-doc-identifier-face)
+      (:match ,elixir--doc-keywords-re @elixir-font-comment-doc-identifier-face))
+
+     (unary_operator operator: "@" @elixir-font-attribute-face
+                     operand: [
+                               (identifier)  @elixir-font-attribute-face
+                               (call target: (identifier)  @elixir-font-attribute-face)
+                               (boolean)  @elixir-font-attribute-face
+                               (nil)  @elixir-font-attribute-face
+                               ])
+
+     (unary_operator operator: "&") @elixir-font-function-face
+     (operator_identifier) @elixir-font-operator-face
+
+     ;; these are operators, should we mark them as keywords?
+     (binary_operator
+      operator: _ @elixir-font-keyword-face
+      (:match ,elixir--reserved-keywords-re @elixir-font-keyword-face))
+
+     (binary_operator operator: _ @elixir-font-operator-face)
+     (dot operator: _ @elixir-font-operator-face)
+     (stab_clause operator: _ @elixir-font-operator-face)
+
+     [(boolean) (nil)] @elixir-font-constant-face
+     [(integer) (float)] @elixir-font-number-face
+     (alias) @elixir-font-module-face
+     (call target: (dot left: (atom) @elixir-font-module-face))
+     (char) @elixir-font-constant-face
+     [(atom) (quoted_atom)] @elixir-font-module-face
+     [(keyword) (quoted_keyword)] @elixir-font-string-special-symbol-face
+
+     (call
+      target: (identifier) @elixir-font-keyword-face
+      (:match ,elixir--definition-keywords-re @elixir-font-keyword-face))
+     (call
+      target: (identifier) @elixir-font-keyword-face
+      (:match ,elixir--kernel-keywords-re @elixir-font-keyword-face))
+     (call
+      target: [(identifier) @elixir-font-function-face
+               (dot right: (identifier) @elixir-font-function-face)])
+     (call
+      target: (identifier) @elixir-font-keyword-face
+      (arguments
+       [
+        (identifier) @elixir-font-function-face
+        (binary_operator
+         left: (identifier) @elixir-font-function-face
+         operator: "when")
+        ])
+      (:match ,elixir--definition-keywords-re @elixir-font-keyword-face))
+     (call
+      target: (identifier) @elixir-font-keyword-face
+      (arguments
+       (binary_operator
+        operator: "|>"
+        right: (identifier) @elixir-font-variable-face))
+      (:match ,elixir--definition-keywords-re @elixir-font-keyword-face))
+
+     (binary_operator operator: "|>" right: (identifier) @elixir-font-function-face)
+     ((identifier) @elixir-font-constant-builtin-face
+      (:match ,elixir--builtin-keywords-re @elixir-font-constant-builtin-face))
+     ((identifier) @elixir-font-comment-unused-face
+      (:match "^_" @elixir-font-comment-unused-face))
+     (identifier) @elixir-font-variable-face
+     ["%"] @elixir-font-punctuation-face
+     ["," ";"] @elixir-font-punctuation-delimiter-face
+     ["(" ")" "[" "]" "{" "}" "<<" ">>"] @elixir-font-punctuation-bracket-face
+
+     (charlist
+      [
+       quoted_end: _ @elixir-font-string-face
+       quoted_start: _ @elixir-font-string-face
+      (quoted_content) @elixir-font-string-face
+      (interpolation
+       "#{"
+       @elixir-font-string-escape-face
+       "}" @elixir-font-string-escape-face)
+      ])
+     (string
+      [
+       quoted_end: _ @elixir-font-string-face
+       quoted_start: _ @elixir-font-string-face
+      (quoted_content) @elixir-font-string-face
+      (interpolation
+       "#{"
+       @elixir-font-string-escape-face
+       "}" @elixir-font-string-escape-face)
+      ]))
+   :language 'elixir
+   :feature 'moderate
+   :override t
+   `(
+     (sigil
+      (sigil_name) @elixir-font-sigil-name-face
+      quoted_start: _ @elixir-font-string-special-face
+      quoted_end: _ @elixir-font-string-special-face) @elixir-font-string-special-face
+     (sigil
+      (sigil_name) @elixir-font-sigil-name-face
+      quoted_start: _ @elixir-font-string-face
+      quoted_end: _ @elixir-font-string-face
+      (:match "^[sS]$" @elixir-font-sigil-name-face)) @elixir-font-string-face
+      (sigil
+      (sigil_name) @elixir-font-sigil-name-face
+      quoted_start: _ @elixir-font-string-regex-face
+      quoted_end: _ @elixir-font-string-regex-face
+      (:match "^[rR]$" @elixir-font-sigil-name-face)) @elixir-font-string-regex-face
+     )
+   :language 'elixir
+   :feature 'elaborate
+   :override t
+   `((escape_sequence) @elixir-font-string-escape-face)
+   )
+  "Tree-sitter font-lock settings.")
+
+(provide 'elixir-tree-sitter)
+
+;;; elixir-tree-sitter.el ends here

--- a/elixir-tree-sitter.el
+++ b/elixir-tree-sitter.el
@@ -181,29 +181,49 @@
 (defvar elixir--treesit-font-lock-settings
   (treesit-font-lock-rules
    :language 'elixir
-   :feature 'minimal
-   `(
-     (comment) @elixir-font-comment-face
+   :feature 'comment
+   '((comment) @elixir-font-comment-face)
 
-     ;; (string
-     ;;  [
-     ;;   quoted_end: _ @elixir-font-string-face
-     ;;   quoted_start: _ @elixir-font-string-face
-     ;;  (quoted_content) @elixir-font-string-face
-     ;;  (interpolation
-     ;;   "#{"
-     ;;   @elixir-font-string-escape-face
-     ;;   "}" @elixir-font-string-escape-face)
-     ;;  ])
+   :language 'elixir
+   :feature 'string
+   :override t
+   '([(string) (charlist)] @font-lock-string-face)
 
+   :language 'elixir
+   :feature 'string-interpolation
+   :override t
+   '((string
+      [
+       quoted_end: _ @elixir-font-string-face
+       quoted_start: _ @elixir-font-string-face
+       (quoted_content) @elixir-font-string-face
+       (interpolation
+        "#{" @elixir-font-string-escape-face "}" @elixir-font-string-escape-face
+        )
+       ])
+     (charlist
+      [
+       quoted_end: _ @elixir-font-string-face
+       quoted_start: _ @elixir-font-string-face
+       (quoted_content) @elixir-font-string-face
+       (interpolation
+        "#{" @elixir-font-string-escape-face "}" @elixir-font-string-escape-face
+        )
+       ])
+     )
 
-     [(string) (charlist)] @font-lock-string-face
-     (interpolation) @default ; color everything in substitution white
-     (interpolation ["#{" "}"] @font-lock-constant-face)
+   :language 'elixir
+   :feature 'keyword
+   ;; :override `prepend
+   `(,elixir--reserved-keywords-vector @elixir-font-keyword-face
+     ;; these are operators, should we mark them as keywords?
+     (binary_operator
+      operator: _ @elixir-font-keyword-face
+      (:match ,elixir--reserved-keywords-re @elixir-font-keyword-face)))
 
-     ,elixir--reserved-keywords-vector @elixir-font-keyword-face
-
-     (unary_operator
+   :language 'elixir
+   :feature 'unary-operator
+   `((unary_operator
       operator: "@" @elixir-font-comment-doc-attribute-face
       operand: (call
                 target: (identifier) @elixir-font-comment-doc-identifier-face
@@ -220,7 +240,6 @@
                   (boolean) @elixir-font-comment-doc-face
                   ]))
       (:match ,elixir--doc-keywords-re @elixir-font-comment-doc-identifier-face))
-
      (unary_operator
       operator: "@" @elixir-font-comment-doc-attribute-face
       operand: (call
@@ -237,13 +256,11 @@
 
      (unary_operator operator: "&") @elixir-font-function-face
      (operator_identifier) @elixir-font-operator-face
+     )
 
-     ;; these are operators, should we mark them as keywords?
-     (binary_operator
-      operator: _ @elixir-font-keyword-face
-      (:match ,elixir--reserved-keywords-re @elixir-font-keyword-face))
-
-     (binary_operator operator: _ @elixir-font-operator-face)
+   :language 'elixir
+   :feature 'operator
+   '((binary_operator operator: _ @elixir-font-operator-face)
      (dot operator: _ @elixir-font-operator-face)
      (stab_clause operator: _ @elixir-font-operator-face)
 
@@ -253,9 +270,11 @@
      (call target: (dot left: (atom) @elixir-font-module-face))
      (char) @elixir-font-constant-face
      [(atom) (quoted_atom)] @elixir-font-module-face
-     [(keyword) (quoted_keyword)] @elixir-font-string-special-symbol-face
+     [(keyword) (quoted_keyword)] @elixir-font-string-special-symbol-face)
 
-     (call
+   :language 'elixir
+   :feature 'call
+   `((call
       target: (identifier) @elixir-font-keyword-face
       (:match ,elixir--definition-keywords-re @elixir-font-keyword-face))
      (call
@@ -280,9 +299,11 @@
        (binary_operator
         operator: "|>"
         right: (identifier) @elixir-font-variable-face))
-      (:match ,elixir--definition-keywords-re @elixir-font-keyword-face))
+      (:match ,elixir--definition-keywords-re @elixir-font-keyword-face)))
 
-     (binary_operator operator: "|>" right: (identifier) @elixir-font-function-face)
+   :language 'elixir
+   :feature 'constant
+   `((binary_operator operator: "|>" right: (identifier) @elixir-font-function-face)
      ((identifier) @elixir-font-constant-builtin-face
       (:match ,elixir--builtin-keywords-re @elixir-font-constant-builtin-face))
      ((identifier) @elixir-font-comment-unused-face
@@ -290,31 +311,10 @@
      (identifier) @elixir-font-variable-face
      ["%"] @elixir-font-punctuation-face
      ["," ";"] @elixir-font-punctuation-delimiter-face
-     ["(" ")" "[" "]" "{" "}" "<<" ">>"] @elixir-font-punctuation-bracket-face
+     ["(" ")" "[" "]" "{" "}" "<<" ">>"] @elixir-font-punctuation-bracket-face)
 
-     ;; (charlist
-     ;;  [
-     ;;   quoted_end: _ @elixir-font-string-face
-     ;;   quoted_start: _ @elixir-font-string-face
-     ;;  (quoted_content) @elixir-font-string-face
-     ;;  (interpolation
-     ;;   "#{"
-     ;;   @elixir-font-string-escape-face
-     ;;   "}" @elixir-font-string-escape-face)
-     ;;  ])
-     ;; (string
-     ;;  [
-     ;;   quoted_end: _ @elixir-font-string-face
-     ;;   quoted_start: _ @elixir-font-string-face
-     ;;  (quoted_content) @elixir-font-string-face
-     ;;  (interpolation
-     ;;   "#{"
-     ;;   @elixir-font-string-escape-face
-     ;;   "}" @elixir-font-string-escape-face)
-     ;;  ])
-     )
    :language 'elixir
-   :feature 'moderate
+   :feature 'sigil
    :override t
    `(
      (sigil
@@ -332,8 +332,9 @@
       quoted_end: _ @elixir-font-string-regex-face
       (:match "^[rR]$" @elixir-font-sigil-name-face)) @elixir-font-string-regex-face
      )
+
    :language 'elixir
-   :feature 'full
+   :feature 'string-escape
    :override t
    `((escape_sequence) @elixir-font-string-escape-face)
    )

--- a/elixir-tree-sitter.el
+++ b/elixir-tree-sitter.el
@@ -24,10 +24,10 @@
 
 ;;; Code:
 
-(require 'treesit nil t)
-
 ;; Custom faces match highlights.scm as close as possible
 ;; to help with updates
+
+(require 'treesit nil t)
 
 (defface elixir-font-keyword-face
   '((t (:inherit font-lock-keyword-face)))
@@ -133,8 +133,6 @@
   '((t (:inherit error)))
   "For use with @comment.unused tag.")
 
-;; Faces end
-
 (defconst elixir--definition-keywords
   '("def" "defdelegate" "defexception" "defguard" "defguardp" "defimpl" "defmacro" "defmacrop" "defmodule" "defn" "defnp" "defoverridable" "defp" "defprotocol" "defstruct"))
 
@@ -162,11 +160,11 @@
 
 (defconst elixir--reserved-keywords
   '("when" "and" "or" "not" "in"
-   "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
+    "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
 
 (defconst elixir--reserved-keywords
   '("when" "and" "or" "not" "in"
-   "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
+    "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
 
 (defconst elixir--reserved-keywords-re
   (concat "^" (regexp-opt elixir--reserved-keywords) "$"))
@@ -278,22 +276,22 @@
       [
        quoted_end: _ @elixir-font-string-face
        quoted_start: _ @elixir-font-string-face
-      (quoted_content) @elixir-font-string-face
-      (interpolation
-       "#{"
-       @elixir-font-string-escape-face
-       "}" @elixir-font-string-escape-face)
-      ])
+       (quoted_content) @elixir-font-string-face
+       (interpolation
+        "#{"
+        @elixir-font-string-escape-face
+        "}" @elixir-font-string-escape-face)
+       ])
      (string
       [
        quoted_end: _ @elixir-font-string-face
        quoted_start: _ @elixir-font-string-face
-      (quoted_content) @elixir-font-string-face
-      (interpolation
-       "#{"
-       @elixir-font-string-escape-face
-       "}" @elixir-font-string-escape-face)
-      ]))
+       (quoted_content) @elixir-font-string-face
+       (interpolation
+        "#{"
+        @elixir-font-string-escape-face
+        "}" @elixir-font-string-escape-face)
+       ]))
    :language 'elixir
    :feature 'moderate
    :override t
@@ -307,7 +305,7 @@
       quoted_start: _ @elixir-font-string-face
       quoted_end: _ @elixir-font-string-face
       (:match "^[sS]$" @elixir-font-sigil-name-face)) @elixir-font-string-face
-      (sigil
+     (sigil
       (sigil_name) @elixir-font-sigil-name-face
       quoted_start: _ @elixir-font-string-regex-face
       quoted_end: _ @elixir-font-string-regex-face

--- a/elixir-tree-sitter.el
+++ b/elixir-tree-sitter.el
@@ -356,8 +356,7 @@
        ])
      (:match ,elixir--definition-keywords-re @type)
      ))))
-    (when (treesit-query-validate 'elixir query)
-      (treesit-query-compile 'elixir query))))
+    (treesit-query-compile 'elixir query)))
 
 (defun elixir--treesit-defun (node)
   "Get the module name from the NODE if exists."

--- a/elixir-tree-sitter.el
+++ b/elixir-tree-sitter.el
@@ -27,7 +27,7 @@
 ;; Custom faces match highlights.scm as close as possible
 ;; to help with updates
 
-(require 'treesit nil t)
+(require 'treesit)
 
 ;; Font lock
 


### PR DESCRIPTION
Add "native" tree-sitter font-lock support. 

This PR is for the feature/tree-sitter emacs branch when it is merged in, but should not break for older versions of emacs, so should be safe to merge.

The emacs starter guide for treesit:
https://github.com/emacs-mirror/emacs/blob/feature/tree-sitter/admin/notes/tree-sitter/starter-guide

### Known issues:
- There are some small issues regarding docstrings when fontification is out of sync, which can be fixed with `C-x x f`
- String interpolation does not show correctly ( This seems to be an issue with the emacs build at the moment, but not sure )

### For the near future:
- Add indentation support
- Add navigation support

### To figure out
- Add heex support

Additional implementation can be found here: https://github.com/wkirschbaum/elixir-mode/blob/main/elixir-mode.el. I will copy over when it feels stable enough using it daily.