### PR TITLE
Delete -emacs-elixir-format files when elixir-format is called uninteractively

### DIFF
--- a/elixir-format.el
+++ b/elixir-format.el
@@ -114,11 +114,12 @@ files in subdirectories."
       (setq our-elixir-format-arguments (append our-elixir-format-arguments elixir-format-arguments)))
     (setq our-elixir-format-arguments (append our-elixir-format-arguments (list tmpfile)))
 
-    (if (zerop (elixir-format--from-mix-root (elixir-format--mix-executable) (elixir-format--errbuff) our-elixir-format-arguments))
-        (elixir-format--call-format-command tmpfile)
-      (elixir-format--failed-to-format called-interactively-p))
-    (delete-file tmpfile)
-    (kill-buffer (elixir-format--outbuff))))
+    (unwind-protect
+        (if (zerop (elixir-format--from-mix-root (elixir-format--mix-executable) (elixir-format--errbuff) our-elixir-format-arguments))
+            (elixir-format--call-format-command tmpfile)
+          (elixir-format--failed-to-format called-interactively-p))
+      (delete-file tmpfile)
+      (kill-buffer (elixir-format--outbuff)))))
 
 (defun elixir-format--call-format-command (tmpfile)
   (if (zerop (call-process-region (point-min) (point-max) "diff" nil (elixir-format--outbuff) nil "-n" "-" tmpfile))


### PR DESCRIPTION
Fixes #497 

My theory for why these files are left behind when using the hook is the `error` call in `elixir-format--failed-to-format`.  Per [the Emacs documentation](https://www.gnu.org/software/emacs/manual/html_node/elisp/Signaling-Errors.html):

> Error processing normally aborts all or part of the running program and returns to a point that is set up to handle the error.

When `elixir-format` is called interactively, the `error` call in `elixir-format--failed-to-format` function is not invoked, which explains why the files are not left behind in that case.

My fix here was just to wrap the piece that sometimes errors in an `unwind-protect` and have `(delete-file ...)` and `(kill-buffer ...)` as unwind forms.