### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: ${{matrix.emacs_version}}
 
       - name: Setup OTP + Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         emacs_version: ['27.2', '26.3', '25.3', 'snapshot']
         otp: ['23.3']
-        elixir: ['1.9.4', '1.11.4', '1.13.3']
+        elixir: ['1.11.4', '1.12.3', '1.13.4', '1.14.3']
 
     steps:
       - name: Setup Emacs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Setup OTP + Elixir
         uses: erlef/setup-beam@v1
         with:
+          version-type: strict
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: test (Emacs ${{matrix.emacs_version}} | Elixir ${{matrix.elixir}} | Erlang/OTP ${{matrix.otp}})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         emacs_version: ['27.2', '26.3', '25.3', 'snapshot']


### PR DESCRIPTION
CI is failing to run for new PRs.

Solution:
- [x] Switch from deprecated `setup-elixir` action to new `setup-beam` action
- [x] Set the version type to 'strict' to prevent `setup-beam` from erroring on OTP specification `23.3`
- [x] Downgrade Ubuntu to 20.04 for compatibility with OTP 23.3 ([Source](https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp))
- [x] Drop Elixir 1.9 (latest update released in November 2019), update the Elixir 1.13 version by a bugfix, add Elixir 1.12 and 1.14.