### PR TITLE
Add prettified symbols

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -444,6 +444,12 @@ is used to limit the scan."
     (,(elixir-rx (group code-point))
      1 font-lock-negation-char-face)))
 
+(defvar elixir-prettify-symbols-alist
+  '(("<-" . ?←) ("->" . ?→) ("=>" . ?⇒)
+    ("!=" . ?≠) ("<=" . ?≤) (">=" . ?≥)
+    ("|>" . ?▷))
+  "Alist of symbol prettifications for use with `prettify-symbols-mode'.")
+
 ;;;###autoload
 (defun elixir-mode-open-github ()
   "Elixir mode open GitHub page."
@@ -587,7 +593,10 @@ just return nil."
               :backward-token 'elixir-smie-backward-token)
   ;; https://github.com/elixir-editors/emacs-elixir/issues/363
   ;; http://debbugs.gnu.org/cgi/bugreport.cgi?bug=35496
-  (setq-local smie-blink-matching-inners nil))
+  (setq-local smie-blink-matching-inners nil)
+
+  ;; Prettify symbols
+  (setq prettify-symbols-alist elixir-prettify-symbols-alist))
 
 ;; Invoke elixir-mode when appropriate
 


### PR DESCRIPTION
Emacs 24.4 (released circa 2014) introduced a minor mode called `prettify-symbols-mode` that, when enabled, will replace a string with a symbol according to the `prettify-symbols-alist`.

As such, and [following loosely from `rust-mode`](https://github.com/rust-lang/rust-mode/blob/22fff6a049402584e7120146c3db141c6f530bf6/rust-mode.el#L46-L50), I added a small set of pretty intuitive symbols for common Elixir constructs.

**Before**
![image](https://user-images.githubusercontent.com/2058614/221389123-fdf37d82-0dfa-41e7-b8dd-0295d292ee04.png)

**After**
![image](https://user-images.githubusercontent.com/2058614/221389144-244741e1-2381-4a17-a263-14ccec7f27a5.png)