### PR TITLE
add H to list of sigil characters

### DIFF
--- a/elixir-mode.el
+++ b/elixir-mode.el
@@ -265,7 +265,7 @@ is used to limit the scan."
   (unless (elixir-syntax-in-string-or-comment-p)
     (let ((heredoc-p (save-excursion
                        (goto-char (match-beginning 0))
-                       (looking-at-p "~[BCDELNRSTUbcersw]\\(?:'''\\|\"\"\"\\)"))))
+                       (looking-at-p "~[BCDEHLNRSTUbcersw]\\(?:'''\\|\"\"\"\\)"))))
       (unless heredoc-p
         (forward-char 1)
         (let* ((start-delim (char-after (1- (point))))


### PR DESCRIPTION
Fixes #501 

This is provided by [Phoenix.Component](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#sigil_H/2) rather than by the standard library, but they're used several times in freshly generated Phoenix projects beginning in version 1.7, and without adding this the font locking quickly goes off the rails in files where `~H"""` is used. although it would be great to have true HTML font locking for dealing with embedded EEx inside heredocs, this was a one-character fix sufficient for my immediate needs, so i figured i would start with this hoping others would find it useful, and then maybe take a deeper look at font locking improvements that would require heavier changes later on.